### PR TITLE
Add mobile navigation fallback

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="mobile-nav.css" />
 </head>
 <body>
 
@@ -29,14 +30,23 @@
         <a href="#resources">Resources</a>
         <a class="nav-button" href="#contact">Contact</a>
       </nav>
+      <a class="mobile-header-contact" href="#contact">Contact</a>
     </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation">
+      <a href="#problems">Problems</a>
+      <a href="#solutions">Solutions</a>
+      <a href="#work">Projects</a>
+      <a href="#products">Products</a>
+      <a href="#resources">Resources</a>
+      <a class="mobile-nav-contact" href="#contact">Contact</a>
+    </nav>
   </header>
 
   <main>
     <section class="hero blueprint-bg">
       <div class="hero-shell">
         <div class="hero-copy reveal">
-          <p class="eyebrow">Manufacturing Solutions • Fixture Design • Tooling</p>
+          <p class="eyebrow">Manufacturing Solutions &bull; Fixture Design &bull; Tooling</p>
           <h1>Helping manufacturers solve production challenges.</h1>
           <p class="hero-text">
             Eden Industrial Systems helps shops, OEMs, and manufacturers reduce setup time, improve throughput, and solve difficult production problems through custom fixtures, tooling, process improvements, and mechanical design.
@@ -212,7 +222,7 @@
               <p class="eyebrow">Improve Manufacturability</p>
               <h3>DFM and component redesign</h3>
               <p>Review parts and assemblies for manufacturability, fabrication risk, and production efficiency.</p>
-              <a href="#contact">Discuss a project →</a>
+              <a href="#contact">Discuss a project &rarr;</a>
             </div>
           </article>
 
@@ -221,7 +231,7 @@
               <p class="eyebrow">Improve Assembly Consistency</p>
               <h3>Repeatable assembly support</h3>
               <p>Tooling and workstation concepts that reduce manual alignment and improve operator workflow.</p>
-              <a href="#contact">Discuss a project →</a>
+              <a href="#contact">Discuss a project &rarr;</a>
             </div>
           </article>
 
@@ -297,7 +307,7 @@
             <p class="eyebrow">Resources</p>
             <h2>Technical articles for manufacturers trying to improve production.</h2>
             <p>
-              Practical guides on setup time, fixture design, workholding, DFM, and production bottlenecks. These resources are written for owners, manufacturing engineers, and production teams that want actionable ideas—not textbook theory.
+              Practical guides on setup time, fixture design, workholding, DFM, and production bottlenecks. These resources are written for owners, manufacturing engineers, and production teams that want actionable ideas&mdash;not textbook theory.
             </p>
           </div>
           <a class="button secondary" href="resources/how-to-reduce-cnc-setup-time.html">Read the First Article</a>
@@ -310,7 +320,7 @@
             <p>
               Setup time is one of the easiest production losses to overlook. This guide explains where time disappears and how fixtures, preparation, and process discipline can improve machine utilization.
             </p>
-            <a class="article-link" href="resources/how-to-reduce-cnc-setup-time.html">Read article →</a>
+            <a class="article-link" href="resources/how-to-reduce-cnc-setup-time.html">Read article &rarr;</a>
           </article>
 
           <article class="article-card">

--- a/mobile-nav.css
+++ b/mobile-nav.css
@@ -1,0 +1,93 @@
+.mobile-header-contact,
+.mobile-nav {
+  display: none;
+}
+
+@media (max-width: 880px) {
+  .header-inner {
+    gap: 16px;
+  }
+
+  .mobile-header-contact {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 16px;
+    border-radius: 4px;
+    background: var(--blue);
+    color: white;
+    box-shadow: 0 10px 22px rgba(6, 63, 143, 0.2);
+    font-size: 0.78rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    text-decoration: none;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .mobile-header-contact:hover {
+    background: var(--blue-dark);
+  }
+
+  .mobile-nav {
+    width: min(1140px, 91%);
+    margin: -6px auto 12px;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 8px;
+    padding-bottom: 2px;
+  }
+
+  .mobile-nav a {
+    min-height: 40px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 10px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: linear-gradient(180deg, #ffffff, #f6f8fb);
+    color: var(--text);
+    box-shadow: 0 8px 18px rgba(6, 26, 56, 0.05);
+    font-size: 0.72rem;
+    font-weight: 900;
+    letter-spacing: 0.05em;
+    line-height: 1.1;
+    text-align: center;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .mobile-nav a:hover {
+    border-color: #b7c5d8;
+    color: var(--blue-bright);
+  }
+
+  .mobile-nav .mobile-nav-contact {
+    background: var(--dark);
+    border-color: var(--dark-2);
+    color: white;
+  }
+
+  .mobile-nav .mobile-nav-contact:hover {
+    color: white;
+    background: var(--blue-dark);
+  }
+}
+
+@media (max-width: 560px) {
+  .mobile-nav {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .mobile-nav a {
+    min-height: 38px;
+    font-size: 0.68rem;
+  }
+
+  .mobile-header-contact {
+    padding: 0 14px;
+    font-size: 0.72rem;
+  }
+}

--- a/resources/how-to-reduce-cnc-setup-time.html
+++ b/resources/how-to-reduce-cnc-setup-time.html
@@ -9,6 +9,7 @@
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../styles.css" />
+  <link rel="stylesheet" href="../mobile-nav.css" />
   <style>
     .article-hero { padding: 78px 0; border-bottom: 1px solid var(--border); background: linear-gradient(180deg, #ffffff, #f6f8fb); }
     .article-hero-grid { display: grid; grid-template-columns: minmax(0, 1.1fr) 380px; gap: 48px; align-items: start; position: relative; z-index: 1; }
@@ -56,7 +57,16 @@
         <a href="../index.html#resources">Resources</a>
         <a class="nav-button" href="../index.html#contact">Contact</a>
       </nav>
+      <a class="mobile-header-contact" href="../index.html#contact">Contact</a>
     </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation">
+      <a href="../index.html#problems">Problems</a>
+      <a href="../index.html#solutions">Solutions</a>
+      <a href="../index.html#work">Projects</a>
+      <a href="../index.html#products">Products</a>
+      <a href="../index.html#resources">Resources</a>
+      <a class="mobile-nav-contact" href="../index.html#contact">Contact</a>
+    </nav>
   </header>
 
   <main>


### PR DESCRIPTION
## Summary
- Adds a lightweight `mobile-nav.css` stylesheet for no-JavaScript mobile navigation.
- Keeps a visible mobile Contact button in the sticky header when the desktop nav is hidden.
- Adds a compact stacked mobile nav with Problems, Solutions, Projects, Products, Resources, and Contact links.
- Applies the same mobile fallback to the homepage and the CNC setup-time resource article with correct relative links from `/resources/`.

## Verification
- Confirmed the homepage now links `mobile-nav.css` and includes mobile header/contact markup.
- Confirmed the resource article now links `../mobile-nav.css` and uses `../index.html#...` links.
- Confirmed the branch changes only touch `index.html`, `resources/how-to-reduce-cnc-setup-time.html`, and the new `mobile-nav.css`.