### PR TITLE
Add accessibility focus and navigation polish

### DIFF
--- a/accessibility.css
+++ b/accessibility.css
@@ -1,0 +1,71 @@
+.skip-link {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  z-index: 999;
+  transform: translateY(-160%);
+  padding: 12px 16px;
+  border-radius: 6px;
+  background: var(--dark);
+  color: white;
+  font-weight: 900;
+  text-decoration: none;
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.24);
+  transition: transform 0.15s ease;
+}
+
+.skip-link:focus,
+.skip-link:focus-visible {
+  transform: translateY(0);
+}
+
+:focus {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 3px solid var(--blue-bright);
+  outline-offset: 4px;
+}
+
+.logo:focus-visible,
+.nav a:focus-visible,
+.mobile-nav a:focus-visible,
+.mobile-header-contact:focus-visible,
+.button:focus-visible,
+.nav-button:focus-visible,
+.article-link:focus-visible,
+.case-study-link:focus-visible,
+.contact-email:focus-visible,
+.breadcrumb:focus-visible,
+.project-copy a:focus-visible,
+.contact-grid a:focus-visible,
+.contact-primary a:focus-visible,
+.aside-card a:focus-visible {
+  border-radius: 6px;
+  outline: 3px solid var(--blue-bright);
+  outline-offset: 4px;
+}
+
+.nav-button:focus-visible,
+.mobile-header-contact:focus-visible,
+.mobile-nav .mobile-nav-contact:focus-visible,
+.button.primary:focus-visible,
+.contact-email:focus-visible {
+  outline-color: #9cc2ff;
+}
+
+.card:focus-within,
+.project-card:focus-within,
+.article-card:focus-within,
+.capability-tags span:focus-within,
+.contact-guidance-card:focus-within,
+.aside-card:focus-within {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.25), var(--shadow);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skip-link {
+    transition: none;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="mobile-nav.css" />
   <link rel="stylesheet" href="project-cases.css" />
   <link rel="stylesheet" href="contact-flow.css" />
+  <link rel="stylesheet" href="accessibility.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -59,6 +60,7 @@
   </script>
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <header class="site-header">
     <div class="container header-inner">
@@ -89,7 +91,7 @@
     </nav>
   </header>
 
-  <main>
+  <main id="main-content">
     <section class="hero blueprint-bg">
       <div class="hero-shell">
         <div class="hero-copy reveal">
@@ -477,12 +479,12 @@
         <div class="capability-panel reveal delay-1">
           <p class="eyebrow">Core Capabilities</p>
           <div class="capability-tags" aria-label="Capabilities">
-            <span><svg viewBox="0 0 24 24"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path></svg>Fixture Design</span>
-            <span><svg viewBox="0 0 24 24"><path d="M14 4l6 6-9 9H5v-6l9-9z"></path><path d="M12 6l6 6"></path></svg>Tooling Design</span>
-            <span><svg viewBox="0 0 24 24"><path d="M12 3l8 4v10l-8 4-8-4V7l8-4z"></path><path d="M4 7l8 4 8-4"></path><path d="M12 11v10"></path></svg>DFM Reviews</span>
-            <span><svg viewBox="0 0 24 24"><path d="M4 5h16v14H4z"></path><path d="M8 9h8M8 13h5"></path></svg>CAD Design</span>
-            <span><svg viewBox="0 0 24 24"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path></svg>Production Tooling</span>
-            <span><svg viewBox="0 0 24 24"><path d="M7 3h8l4 4v14H7z"></path><path d="M15 3v5h4"></path><path d="M10 13h6M10 17h6"></path></svg>Product Development</span>
+            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path></svg>Fixture Design</span>
+            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 4l6 6-9 9H5v-6l9-9z"></path><path d="M12 6l6 6"></path></svg>Tooling Design</span>
+            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 3l8 4v10l-8 4-8-4V7l8-4z"></path><path d="M4 7l8 4 8-4"></path><path d="M12 11v10"></path></svg>DFM Reviews</span>
+            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 5h16v14H4z"></path><path d="M8 9h8M8 13h5"></path></svg>CAD Design</span>
+            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path></svg>Production Tooling</span>
+            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 3h8l4 4v14H7z"></path><path d="M15 3v5h4"></path><path d="M10 13h6M10 17h6"></path></svg>Product Development</span>
           </div>
         </div>
       </div>

--- a/resources/how-to-reduce-cnc-setup-time.html
+++ b/resources/how-to-reduce-cnc-setup-time.html
@@ -25,6 +25,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="../styles.css" />
   <link rel="stylesheet" href="../mobile-nav.css" />
+  <link rel="stylesheet" href="../accessibility.css" />
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -94,6 +95,7 @@
   </style>
 </head>
 <body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <header class="site-header">
     <div class="container header-inner">
@@ -121,7 +123,7 @@
     </nav>
   </header>
 
-  <main>
+  <main id="main-content">
     <section class="article-hero blueprint-bg">
       <div class="container article-hero-grid">
         <div class="reveal">


### PR DESCRIPTION
## Summary
- Adds `accessibility.css` with visible `:focus-visible` styles for navigation, buttons, links, cards, project CTAs, article links, and contact CTAs.
- Adds skip links to the homepage and CNC setup-time article.
- Adds `id="main-content"` targets so skip links move keyboard users directly to the main content.
- Marks decorative capability icons as `aria-hidden="true"` and `focusable="false"`.
- Preserves reduced-motion behavior by disabling skip-link transition when users prefer reduced motion.

## Verification
- Confirmed homepage and article both load the accessibility stylesheet.
- Confirmed skip links point to existing `main-content` landmarks.
- Confirmed capability SVG icons are hidden from assistive technology.
- Confirmed changes stay static and dependency-free.