### PR TITLE
Add dedicated service pages

### DIFF
--- a/dfm-review.html
+++ b/dfm-review.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>DFM Review | Eden Industrial Systems</title>
+  <meta name="description" content="Design for manufacturing review support for parts and assemblies that need cleaner drawings, lower fabrication risk, clearer datums, and production-ready details." />
+  <link rel="canonical" href="https://edenindustrialsystems.com/dfm-review.html" />
+  <meta name="theme-color" content="#063f8f" />
+  <meta property="og:title" content="DFM Review | Eden Industrial Systems" />
+  <meta property="og:description" content="Manufacturing-first DFM review for parts, assemblies, drawings, datums, tolerances, and vendor-ready details." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://edenindustrialsystems.com/dfm-review.html" />
+  <meta property="og:site_name" content="Eden Industrial Systems" />
+  <meta property="og:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="DFM Review | Eden Industrial Systems" />
+  <meta name="twitter:description" content="DFM review for manufacturability, drawing clarity, tolerance risk, and production-ready design details." />
+  <meta name="twitter:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="mobile-nav.css" />
+  <link rel="stylesheet" href="service-pages.css" />
+  <link rel="stylesheet" href="contact-flow.css" />
+  <link rel="stylesheet" href="accessibility.css" />
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Service","name":"DFM Review","provider":{"@type":"ProfessionalService","name":"Eden Industrial Systems","url":"https://edenindustrialsystems.com/"},"serviceType":"Design for manufacturing review","areaServed":"United States","url":"https://edenindustrialsystems.com/dfm-review.html"}
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="index.html" aria-label="Eden Industrial Systems home"><span class="logo-mark">E</span><span><strong>Eden</strong><small>Industrial Systems</small></span></a>
+      <nav class="nav" aria-label="Primary navigation"><a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="nav-button" href="index.html#contact">Contact</a></nav>
+      <a class="mobile-header-contact" href="index.html#contact">Contact</a>
+    </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation"><a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="mobile-nav-contact" href="index.html#contact">Contact</a></nav>
+  </header>
+
+  <main id="main-content">
+    <section class="service-hero blueprint-bg">
+      <div class="container service-hero-grid">
+        <div class="reveal">
+          <a class="breadcrumb" href="index.html#solutions">Back to Solutions</a>
+          <p class="eyebrow">DFM Review</p>
+          <h1>Review parts and drawings before they become production problems.</h1>
+          <p class="hero-text">Eden Industrial Systems reviews parts, assemblies, and drawings for manufacturability, fabrication risk, tolerance clarity, tool access, inspection burden, and vendor interpretation issues.</p>
+          <div class="hero-actions"><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Request a DFM Review</a><a class="button secondary" href="manufacturing-engineering-support.html">Engineering Support</a></div>
+        </div>
+        <aside class="service-summary-card reveal delay-1" aria-label="DFM review summary"><p class="eyebrow">Best Fit</p><h2>Use DFM review before cost, scrap, or supplier confusion grows.</h2><ul class="service-summary-list"><li>Drawings are hard to quote or interpret.</li><li>Features are difficult to machine, inspect, fabricate, or assemble.</li><li>Tolerances may be tighter than the function needs.</li><li>Parts need cleaner manufacturing intent before release.</li></ul></aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container service-page-layout">
+        <div class="service-main-grid">
+          <section class="service-panel"><p class="eyebrow">Problem Statement</p><h2>Manufacturability is easiest to improve before the part reaches the floor.</h2><p>Small design details can create expensive problems: awkward tool access, unclear datums, unnecessary tight tolerances, difficult inspection, risky fabrication steps, or drawings that leave too much room for interpretation.</p><p>A practical DFM review helps identify those issues early and turn them into buildable recommendations.</p></section>
+          <section class="service-panel-grid" aria-label="DFM review details">
+            <div class="service-panel"><p class="eyebrow">Services Included</p><h2>DFM review can include:</h2><ul class="service-list"><li>Part geometry and manufacturability review.</li><li>Drawing clarity and datum strategy review.</li><li>Tolerance, inspection, and feature-risk feedback.</li><li>Machining, fabrication, or assembly access review.</li><li>Recommended design or documentation changes.</li></ul></div>
+            <div class="service-panel"><p class="eyebrow">Typical Deliverables</p><h2>Clear feedback for design and production teams.</h2><ul class="service-list"><li>DFM issue summary.</li><li>Annotated screenshots or drawing comments.</li><li>Redesign concepts or CAD updates when needed.</li><li>Manufacturing drawing revisions.</li><li>Vendor-ready notes and practical next steps.</li></ul></div>
+          </section>
+          <section class="service-panel"><p class="eyebrow">Industries Served</p><h2>Useful for new products and legacy designs.</h2><ul class="service-chip-list"><li>Machined components</li><li>Fabricated parts</li><li>Assemblies</li><li>Industrial equipment</li><li>Medical device manufacturing</li><li>Aerospace suppliers</li></ul></section>
+        </div>
+        <aside class="service-sidebar" aria-label="DFM review related services"><div class="service-cta-card"><p class="eyebrow">Start Here</p><h2>Have a part or drawing to review?</h2><p>Send the drawing, CAD screenshot, current issue, and what you want to improve.</p><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Email Engineering</a></div><div class="service-cta-card"><p class="eyebrow">Related Services</p><nav class="related-service-links" aria-label="Related service pages"><a href="manufacturing-engineering-support.html">Manufacturing Engineering <span>&rarr;</span></a><a href="fixture-design.html">Fixture Design <span>&rarr;</span></a><a href="production-tooling.html">Production Tooling <span>&rarr;</span></a></nav></div></aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/fixture-design.html
+++ b/fixture-design.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Custom Fixture Design | Eden Industrial Systems</title>
+  <meta name="description" content="Custom fixture design for manufacturers that need faster setup, repeatable part location, safer clamping, and vendor-ready fixture details." />
+  <link rel="canonical" href="https://edenindustrialsystems.com/fixture-design.html" />
+  <meta name="theme-color" content="#063f8f" />
+  <meta property="og:title" content="Custom Fixture Design | Eden Industrial Systems" />
+  <meta property="og:description" content="Fixture concepts, CAD, drawings, and vendor-ready details for repeatable manufacturing setups." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://edenindustrialsystems.com/fixture-design.html" />
+  <meta property="og:site_name" content="Eden Industrial Systems" />
+  <meta property="og:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Custom Fixture Design | Eden Industrial Systems" />
+  <meta name="twitter:description" content="Custom fixture design for faster setup, repeatable part location, safer clamping, and production support." />
+  <meta name="twitter:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="mobile-nav.css" />
+  <link rel="stylesheet" href="service-pages.css" />
+  <link rel="stylesheet" href="contact-flow.css" />
+  <link rel="stylesheet" href="accessibility.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "name": "Custom Fixture Design",
+    "provider": {
+      "@type": "ProfessionalService",
+      "name": "Eden Industrial Systems",
+      "url": "https://edenindustrialsystems.com/"
+    },
+    "serviceType": "Fixture design",
+    "areaServed": "United States",
+    "url": "https://edenindustrialsystems.com/fixture-design.html"
+  }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="index.html" aria-label="Eden Industrial Systems home">
+        <span class="logo-mark">E</span>
+        <span><strong>Eden</strong><small>Industrial Systems</small></span>
+      </a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="index.html#problems">Problems</a>
+        <a href="index.html#solutions">Solutions</a>
+        <a href="index.html#work">Projects</a>
+        <a href="index.html#products">Products</a>
+        <a href="index.html#resources">Resources</a>
+        <a class="nav-button" href="index.html#contact">Contact</a>
+      </nav>
+      <a class="mobile-header-contact" href="index.html#contact">Contact</a>
+    </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation">
+      <a href="index.html#problems">Problems</a>
+      <a href="index.html#solutions">Solutions</a>
+      <a href="index.html#work">Projects</a>
+      <a href="index.html#products">Products</a>
+      <a href="index.html#resources">Resources</a>
+      <a class="mobile-nav-contact" href="index.html#contact">Contact</a>
+    </nav>
+  </header>
+
+  <main id="main-content">
+    <section class="service-hero blueprint-bg">
+      <div class="container service-hero-grid">
+        <div class="reveal">
+          <a class="breadcrumb" href="index.html#solutions">Back to Solutions</a>
+          <p class="eyebrow">Custom Fixture Design</p>
+          <h1>Fixtures built around the production problem.</h1>
+          <p class="hero-text">Eden Industrial Systems designs practical fixtures that improve part location, setup speed, clamping access, and repeatability for machining, assembly, and inspection work.</p>
+          <div class="hero-actions">
+            <a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Discuss a Fixture</a>
+            <a class="button secondary" href="workholding-design.html">Workholding Design</a>
+          </div>
+        </div>
+        <aside class="service-summary-card reveal delay-1" aria-label="Fixture design summary">
+          <p class="eyebrow">Best Fit</p>
+          <h2>Use fixture design when the setup repeats or quality depends on location.</h2>
+          <ul class="service-summary-list">
+            <li>Long setup or changeover time.</li>
+            <li>Operator-dependent part location.</li>
+            <li>Clamping that blocks tools or inspection.</li>
+            <li>Repeat jobs that need clearer setup discipline.</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container service-page-layout">
+        <div class="service-main-grid">
+          <section class="service-panel">
+            <p class="eyebrow">Problem Statement</p>
+            <h2>Good fixtures make the correct setup easier to repeat.</h2>
+            <p>A fixture should do more than hold a part. It should guide loading, control datums, simplify clamping, protect access, and help operators make consistent decisions across shifts and repeat jobs.</p>
+            <p>The design work starts with the part, machine, operator, tooling, chips, inspection plan, and production volume. The goal is a buildable fixture that supports real shop-floor use.</p>
+          </section>
+
+          <section class="service-panel-grid" aria-label="Fixture design details">
+            <div class="service-panel">
+              <p class="eyebrow">Services Included</p>
+              <h2>Fixture support can include:</h2>
+              <ul class="service-list">
+                <li>Machining fixture concepts.</li>
+                <li>Assembly and inspection fixture layouts.</li>
+                <li>Locating pins, nests, stops, and datum strategy.</li>
+                <li>Clamp access, tool access, and chip clearance review.</li>
+                <li>Operator loading and setup sequence considerations.</li>
+              </ul>
+            </div>
+            <div class="service-panel">
+              <p class="eyebrow">Typical Deliverables</p>
+              <h2>Practical details for review and build.</h2>
+              <ul class="service-list">
+                <li>Fixture concept sketches or CAD layouts.</li>
+                <li>3D CAD models and review images.</li>
+                <li>Vendor-ready drawings and notes.</li>
+                <li>Hardware, clamp, and purchased component references.</li>
+                <li>Implementation notes for setup and use.</li>
+              </ul>
+            </div>
+          </section>
+
+          <section class="service-panel">
+            <p class="eyebrow">Industries Served</p>
+            <h2>Built for manufacturers with repeatable work.</h2>
+            <ul class="service-chip-list">
+              <li>Precision machining</li>
+              <li>Medical device manufacturing</li>
+              <li>Aerospace suppliers</li>
+              <li>Industrial equipment</li>
+              <li>Electronics manufacturing</li>
+              <li>Automation integrators</li>
+            </ul>
+          </section>
+        </div>
+
+        <aside class="service-sidebar" aria-label="Fixture design related services">
+          <div class="service-cta-card">
+            <p class="eyebrow">Start Here</p>
+            <h2>Have a fixture or setup problem?</h2>
+            <p>Send a part drawing, setup photo, pain point, or rough goal. A polished scope is not required.</p>
+            <a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Email Engineering</a>
+          </div>
+          <div class="service-cta-card">
+            <p class="eyebrow">Related Services</p>
+            <nav class="related-service-links" aria-label="Related service pages">
+              <a href="workholding-design.html">Workholding Design <span>&rarr;</span></a>
+              <a href="manufacturing-engineering-support.html">Manufacturing Engineering <span>&rarr;</span></a>
+              <a href="production-tooling.html">Production Tooling <span>&rarr;</span></a>
+            </nav>
+          </div>
+        </aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
   <link rel="stylesheet" href="styles.css" />
   <link rel="stylesheet" href="mobile-nav.css" />
   <link rel="stylesheet" href="project-cases.css" />
+  <link rel="stylesheet" href="service-pages.css" />
   <link rel="stylesheet" href="contact-flow.css" />
   <link rel="stylesheet" href="accessibility.css" />
   <script type="application/ld+json">
@@ -37,25 +38,8 @@
     "email": "engineering@edenindustrialsystems.com",
     "description": "Manufacturing solutions, custom fixtures, tooling, workholding, process improvement, mechanical design, and manufacturing engineering support.",
     "areaServed": "United States",
-    "serviceType": [
-      "Custom fixture design",
-      "Tooling design",
-      "Workholding concepts",
-      "Production improvement",
-      "DFM reviews",
-      "Manufacturing engineering support",
-      "Mechanical design"
-    ],
-    "knowsAbout": [
-      "Fixture design",
-      "Manufacturing engineering",
-      "CNC setup time reduction",
-      "Production bottlenecks",
-      "Workholding",
-      "Tooling",
-      "DFM",
-      "Mechanical design"
-    ]
+    "serviceType": ["Custom fixture design", "Tooling design", "Workholding concepts", "Production improvement", "DFM reviews", "Manufacturing engineering support", "Mechanical design"],
+    "knowsAbout": ["Fixture design", "Manufacturing engineering", "CNC setup time reduction", "Production bottlenecks", "Workholding", "Tooling", "DFM", "Mechanical design"]
   }
   </script>
 </head>
@@ -66,10 +50,7 @@
     <div class="container header-inner">
       <a class="logo" href="#" aria-label="Eden Industrial Systems home">
         <span class="logo-mark">E</span>
-        <span>
-          <strong>Eden</strong>
-          <small>Industrial Systems</small>
-        </span>
+        <span><strong>Eden</strong><small>Industrial Systems</small></span>
       </a>
       <nav class="nav" aria-label="Primary navigation">
         <a href="#problems">Problems</a>
@@ -97,15 +78,12 @@
         <div class="hero-copy reveal">
           <p class="eyebrow">Manufacturing Solutions &bull; Fixture Design &bull; Tooling</p>
           <h1>Helping manufacturers solve production challenges.</h1>
-          <p class="hero-text">
-            Eden Industrial Systems helps shops, OEMs, and manufacturers reduce setup time, improve throughput, and solve difficult production problems through custom fixtures, tooling, process improvements, and mechanical design.
-          </p>
+          <p class="hero-text">Eden Industrial Systems helps shops, OEMs, and manufacturers reduce setup time, improve throughput, and solve difficult production problems through custom fixtures, tooling, process improvements, and mechanical design.</p>
           <div class="hero-actions">
             <a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Discuss a Production Problem</a>
             <a class="button secondary" href="#solutions">See How We Help</a>
           </div>
         </div>
-
         <figure class="hero-visual reveal delay-1">
           <img src="assets/hero-manufacturing-systems.svg" alt="CAD-style fixture, tooling, and production workflow illustration" />
         </figure>
@@ -114,42 +92,10 @@
 
     <section class="outcome-strip" aria-label="Engineering outcomes">
       <div class="container outcome-grid">
-        <article class="outcome-item reveal">
-          <span class="outcome-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 2v4M12 18v4M2 12h4M18 12h4"></path></svg>
-          </span>
-          <div>
-            <h2>Reduce Setup Time</h2>
-            <p>Fixture and tooling concepts built to make repeat jobs faster.</p>
-          </div>
-        </article>
-        <article class="outcome-item reveal delay-1">
-          <span class="outcome-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M4 19h16"></path><path d="M7 16l4-5 3 3 5-8"></path><path d="M15 6h4v4"></path></svg>
-          </span>
-          <div>
-            <h2>Increase Throughput</h2>
-            <p>Remove bottlenecks that limit production flow and capacity.</p>
-          </div>
-        </article>
-        <article class="outcome-item reveal delay-2">
-          <span class="outcome-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 5-3 8-7 10-4-2-7-5-7-10V6l7-3z"></path><path d="M8.5 12l2.2 2.2 4.8-5"></path></svg>
-          </span>
-          <div>
-            <h2>Improve Repeatability</h2>
-            <p>Reduce variation from part location, operator adjustment, and manual handling.</p>
-          </div>
-        </article>
-        <article class="outcome-item reveal delay-3">
-          <span class="outcome-icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 7v5l3 2"></path></svg>
-          </span>
-          <div>
-            <h2>Support Production</h2>
-            <p>Provide practical CAD, drawings, and vendor-ready details.</p>
-          </div>
-        </article>
+        <article class="outcome-item reveal"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 2v4M12 18v4M2 12h4M18 12h4"></path></svg></span><div><h2>Reduce Setup Time</h2><p>Fixture and tooling concepts built to make repeat jobs faster.</p></div></article>
+        <article class="outcome-item reveal delay-1"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M4 19h16"></path><path d="M7 16l4-5 3 3 5-8"></path><path d="M15 6h4v4"></path></svg></span><div><h2>Increase Throughput</h2><p>Remove bottlenecks that limit production flow and capacity.</p></div></article>
+        <article class="outcome-item reveal delay-2"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 5-3 8-7 10-4-2-7-5-7-10V6l7-3z"></path><path d="M8.5 12l2.2 2.2 4.8-5"></path></svg></span><div><h2>Improve Repeatability</h2><p>Reduce variation from part location, operator adjustment, and manual handling.</p></div></article>
+        <article class="outcome-item reveal delay-3"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 7v5l3 2"></path></svg></span><div><h2>Support Production</h2><p>Provide practical CAD, drawings, and vendor-ready details.</p></div></article>
       </div>
     </section>
 
@@ -158,20 +104,10 @@
         <div class="section-heading left-heading reveal">
           <p class="eyebrow">Common Problems</p>
           <h2>Is your production fighting the same issues every week?</h2>
-          <p>
-            The right fixture, tool, production aid, or mechanical design improvement can remove friction from the process and make output more predictable.
-          </p>
+          <p>The right fixture, tool, production aid, or mechanical design improvement can remove friction from the process and make output more predictable.</p>
         </div>
-
         <div class="problem-list reveal delay-1">
-          <span>Long setup or changeover times</span>
-          <span>Operator-dependent quality</span>
-          <span>Inconsistent part location</span>
-          <span>Difficult assembly operations</span>
-          <span>Manual processes slowing output</span>
-          <span>Engineering backlog</span>
-          <span>Missing or outdated manufacturing drawings</span>
-          <span>Production bottlenecks</span>
+          <span>Long setup or changeover times</span><span>Operator-dependent quality</span><span>Inconsistent part location</span><span>Difficult assembly operations</span><span>Manual processes slowing output</span><span>Engineering backlog</span><span>Missing or outdated manufacturing drawings</span><span>Production bottlenecks</span>
         </div>
       </div>
     </section>
@@ -181,52 +117,29 @@
         <div class="section-heading left-heading reveal">
           <p class="eyebrow">Solutions</p>
           <h2>Engineering support organized around the production problem.</h2>
-          <p>
-            CAD is the tool. The goal is a production solution that improves how the work actually gets done.
-          </p>
+          <p>CAD is the tool. The goal is a production solution that improves how the work actually gets done.</p>
         </div>
-
         <div class="cards service-cards">
           <article class="card reveal">
-            <span class="card-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path><path d="M3 21h18"></path></svg>
-            </span>
+            <span class="card-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path><path d="M3 21h18"></path></svg></span>
             <h3>Production Improvement</h3>
             <p>Identify bottlenecks, wasted motion, manual adjustment, and quality risks that slow production.</p>
-            <ul>
-              <li>Bottleneck review</li>
-              <li>Process improvement</li>
-              <li>DFM and manufacturability review</li>
-              <li>Manufacturing documentation</li>
-            </ul>
+            <ul><li>Bottleneck review</li><li>Process improvement</li><li>DFM and manufacturability review</li><li>Manufacturing documentation</li></ul>
+            <div class="service-card-links" aria-label="Production improvement service pages"><a class="service-card-link" href="manufacturing-engineering-support.html">Engineering Support</a><a class="service-card-link" href="dfm-review.html">DFM Review</a></div>
           </article>
-
           <article class="card reveal delay-1">
-            <span class="card-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path><path d="M14 11h5"></path><path d="M14 15h5"></path></svg>
-            </span>
+            <span class="card-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path><path d="M14 11h5"></path><path d="M14 15h5"></path></svg></span>
             <h3>Fixture & Tooling Design</h3>
             <p>Purpose-built fixtures and tools that make setup, loading, clamping, inspection, and assembly more repeatable.</p>
-            <ul>
-              <li>Machining fixtures</li>
-              <li>Assembly fixtures</li>
-              <li>Inspection fixtures</li>
-              <li>Workholding concepts</li>
-            </ul>
+            <ul><li>Machining fixtures</li><li>Assembly fixtures</li><li>Inspection fixtures</li><li>Workholding concepts</li></ul>
+            <div class="service-card-links" aria-label="Fixture and tooling service pages"><a class="service-card-link" href="fixture-design.html">Fixture Design</a><a class="service-card-link" href="workholding-design.html">Workholding</a><a class="service-card-link" href="production-tooling.html">Tooling</a></div>
           </article>
-
           <article class="card reveal delay-2">
-            <span class="card-icon" aria-hidden="true">
-              <svg viewBox="0 0 24 24"><path d="M5 7h14v10H5z"></path><path d="M8 7V4h8v3"></path><path d="M8 20h8"></path><path d="M10 17v3M14 17v3"></path></svg>
-            </span>
+            <span class="card-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 7h14v10H5z"></path><path d="M8 7V4h8v3"></path><path d="M8 20h8"></path><path d="M10 17v3M14 17v3"></path></svg></span>
             <h3>Custom Equipment & Product Development</h3>
             <p>Mechanical systems, production aids, and product concepts developed for real-world manufacturing constraints.</p>
-            <ul>
-              <li>Production aids</li>
-              <li>Material handling aids</li>
-              <li>Prototype development</li>
-              <li>Manufacturing-ready drawings</li>
-            </ul>
+            <ul><li>Production aids</li><li>Material handling aids</li><li>Prototype development</li><li>Manufacturing-ready drawings</li></ul>
+            <div class="service-card-links" aria-label="Custom equipment service pages"><a class="service-card-link" href="production-tooling.html">Production Tooling</a><a class="service-card-link" href="manufacturing-engineering-support.html">Engineering Support</a></div>
           </article>
         </div>
       </div>
@@ -234,310 +147,32 @@
 
     <section id="industries" class="section industries-section">
       <div class="container">
-        <div class="section-heading left-heading reveal">
-          <p class="eyebrow">Industries</p>
-          <h2>Built for manufacturers with expensive production problems.</h2>
-        </div>
-        <div class="industry-grid reveal delay-1">
-          <span>Precision Machining</span>
-          <span>Medical Device Manufacturing</span>
-          <span>Industrial Equipment</span>
-          <span>Automation Integrators</span>
-          <span>Aerospace Suppliers</span>
-          <span>Electronics Manufacturing</span>
-        </div>
+        <div class="section-heading left-heading reveal"><p class="eyebrow">Industries</p><h2>Built for manufacturers with expensive production problems.</h2></div>
+        <div class="industry-grid reveal delay-1"><span>Precision Machining</span><span>Medical Device Manufacturing</span><span>Industrial Equipment</span><span>Automation Integrators</span><span>Aerospace Suppliers</span><span>Electronics Manufacturing</span></div>
       </div>
     </section>
 
     <section id="work" class="section muted blueprint-bg-soft">
       <div class="container">
-        <div class="section-heading left-heading reveal">
-          <p class="eyebrow">Manufacturing Challenges</p>
-          <h2>Project examples built around outcomes, not deliverables.</h2>
-          <p>These customer-safe examples show the type of production problem, engineering approach, and practical outcome Eden Industrial Systems is built to support.</p>
-        </div>
-
+        <div class="section-heading left-heading reveal"><p class="eyebrow">Manufacturing Challenges</p><h2>Project examples built around outcomes, not deliverables.</h2><p>These customer-safe examples show the type of production problem, engineering approach, and practical outcome Eden Industrial Systems is built to support.</p></div>
         <div class="project-grid reveal delay-1">
-          <article class="project-card large-project">
-            <img src="assets/project-fixture-system.svg" alt="CAD-style machining fixture with locating pins, clamps, and datum references" />
-            <div class="project-copy">
-              <p class="eyebrow">Reduce Setup Time</p>
-              <h3>Machining fixture system</h3>
-              <p>Flexible workholding concepts that improve part location, setup speed, and repeatability.</p>
-              <div class="case-study-list" aria-label="Machining fixture system case study details">
-                <div class="case-study-item">
-                  <span class="case-study-label">Problem</span>
-                  <span class="case-study-text">Repeat jobs required manual locating, indicating, and clamp adjustment, making setup time difficult to predict.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Approach</span>
-                  <span class="case-study-text">Develop a fixture concept with positive datums, repeatable mounting, accessible clamping, and chip-clearance considerations.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Outcome</span>
-                  <span class="case-study-text">A more repeatable setup path with fewer operator-dependent decisions and clearer first-piece preparation.</span>
-                </div>
-              </div>
-            </div>
-          </article>
-
-          <article class="project-card large-project">
-            <img src="assets/project-dfm-redesign.svg" alt="Technical DFM redesign illustration comparing a component before and after manufacturability review" />
-            <div class="project-copy">
-              <p class="eyebrow">Improve Manufacturability</p>
-              <h3>DFM and component redesign</h3>
-              <p>Review parts and assemblies for manufacturability, fabrication risk, and production efficiency.</p>
-              <div class="case-study-list" aria-label="DFM and component redesign case study details">
-                <div class="case-study-item">
-                  <span class="case-study-label">Problem</span>
-                  <span class="case-study-text">Part features increased machining difficulty, inspection effort, and vendor interpretation risk.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Approach</span>
-                  <span class="case-study-text">Review geometry, datum strategy, tolerance stackups, tool access, and drawing clarity against real manufacturing constraints.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Outcome</span>
-                  <span class="case-study-text">Cleaner manufacturing intent, reduced ambiguity for suppliers, and a design direction better suited for production.</span>
-                </div>
-              </div>
-              <a class="case-study-link" href="#contact">Discuss a project &rarr;</a>
-            </div>
-          </article>
-
-          <article class="project-card large-project">
-            <img src="assets/project-assembly-tooling.svg" alt="Assembly tooling illustration with locating nests, alignment pins, and operator workflow arrows" />
-            <div class="project-copy">
-              <p class="eyebrow">Improve Assembly Consistency</p>
-              <h3>Repeatable assembly support</h3>
-              <p>Tooling and workstation concepts that reduce manual alignment and improve operator workflow.</p>
-              <div class="case-study-list" aria-label="Repeatable assembly support case study details">
-                <div class="case-study-item">
-                  <span class="case-study-label">Problem</span>
-                  <span class="case-study-text">Assembly quality depended on operator feel, manual alignment, and repeated checking during the build.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Approach</span>
-                  <span class="case-study-text">Create tooling concepts with nests, stops, alignment features, access for hands and tools, and a clearer assembly sequence.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Outcome</span>
-                  <span class="case-study-text">A more controlled workflow that supports consistent loading, simpler training, and less rework from alignment variation.</span>
-                </div>
-              </div>
-              <a class="case-study-link" href="#contact">Discuss a project &rarr;</a>
-            </div>
-          </article>
-
-          <article class="project-card large-project">
-            <img src="assets/project-production-aid.svg" alt="CAD-style production aid with workstation, material handling, and workflow elements" />
-            <div class="project-copy">
-              <p class="eyebrow">Increase Capacity</p>
-              <h3>Production aid design</h3>
-              <p>Mechanical systems and production tools designed to remove friction from manufacturing operations.</p>
-              <div class="case-study-list" aria-label="Production aid design case study details">
-                <div class="case-study-item">
-                  <span class="case-study-label">Problem</span>
-                  <span class="case-study-text">Material handling, staging, or manual movement slowed the operation and pulled attention away from value-added work.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Approach</span>
-                  <span class="case-study-text">Design a practical aid around floor space, operator reach, part protection, maintenance access, and vendor-ready fabrication details.</span>
-                </div>
-                <div class="case-study-item">
-                  <span class="case-study-label">Outcome</span>
-                  <span class="case-study-text">A production-focused mechanical concept that reduces wasted motion and helps the team keep work moving predictably.</span>
-                </div>
-              </div>
-            </div>
-          </article>
+          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style machining fixture with locating pins, clamps, and datum references" /><div class="project-copy"><p class="eyebrow">Reduce Setup Time</p><h3>Machining fixture system</h3><p>Flexible workholding concepts that improve part location, setup speed, and repeatability.</p><div class="case-study-list" aria-label="Machining fixture system case study details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">Repeat jobs required manual locating, indicating, and clamp adjustment, making setup time difficult to predict.</span></div><div class="case-study-item"><span class="case-study-label">Approach</span><span class="case-study-text">Develop a fixture concept with positive datums, repeatable mounting, accessible clamping, and chip-clearance considerations.</span></div><div class="case-study-item"><span class="case-study-label">Outcome</span><span class="case-study-text">A more repeatable setup path with fewer operator-dependent decisions and clearer first-piece preparation.</span></div></div></div></article>
+          <article class="project-card large-project"><img src="assets/project-dfm-redesign.svg" alt="Technical DFM redesign illustration comparing a component before and after manufacturability review" /><div class="project-copy"><p class="eyebrow">Improve Manufacturability</p><h3>DFM and component redesign</h3><p>Review parts and assemblies for manufacturability, fabrication risk, and production efficiency.</p><div class="case-study-list" aria-label="DFM and component redesign case study details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">Part features increased machining difficulty, inspection effort, and vendor interpretation risk.</span></div><div class="case-study-item"><span class="case-study-label">Approach</span><span class="case-study-text">Review geometry, datum strategy, tolerance stackups, tool access, and drawing clarity against real manufacturing constraints.</span></div><div class="case-study-item"><span class="case-study-label">Outcome</span><span class="case-study-text">Cleaner manufacturing intent, reduced ambiguity for suppliers, and a design direction better suited for production.</span></div></div><a class="case-study-link" href="#contact">Discuss a project &rarr;</a></div></article>
+          <article class="project-card large-project"><img src="assets/project-assembly-tooling.svg" alt="Assembly tooling illustration with locating nests, alignment pins, and operator workflow arrows" /><div class="project-copy"><p class="eyebrow">Improve Assembly Consistency</p><h3>Repeatable assembly support</h3><p>Tooling and workstation concepts that reduce manual alignment and improve operator workflow.</p><div class="case-study-list" aria-label="Repeatable assembly support case study details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">Assembly quality depended on operator feel, manual alignment, and repeated checking during the build.</span></div><div class="case-study-item"><span class="case-study-label">Approach</span><span class="case-study-text">Create tooling concepts with nests, stops, alignment features, access for hands and tools, and a clearer assembly sequence.</span></div><div class="case-study-item"><span class="case-study-label">Outcome</span><span class="case-study-text">A more controlled workflow that supports consistent loading, simpler training, and less rework from alignment variation.</span></div></div><a class="case-study-link" href="#contact">Discuss a project &rarr;</a></div></article>
+          <article class="project-card large-project"><img src="assets/project-production-aid.svg" alt="CAD-style production aid with workstation, material handling, and workflow elements" /><div class="project-copy"><p class="eyebrow">Increase Capacity</p><h3>Production aid design</h3><p>Mechanical systems and production tools designed to remove friction from manufacturing operations.</p><div class="case-study-list" aria-label="Production aid design case study details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">Material handling, staging, or manual movement slowed the operation and pulled attention away from value-added work.</span></div><div class="case-study-item"><span class="case-study-label">Approach</span><span class="case-study-text">Design a practical aid around floor space, operator reach, part protection, maintenance access, and vendor-ready fabrication details.</span></div><div class="case-study-item"><span class="case-study-label">Outcome</span><span class="case-study-text">A production-focused mechanical concept that reduces wasted motion and helps the team keep work moving predictably.</span></div></div></div></article>
         </div>
       </div>
     </section>
 
-    <section id="products" class="section product-section blueprint-corner">
-      <div class="container product-grid">
-        <div class="section-heading left-heading reveal">
-          <p class="eyebrow">Products in Development</p>
-          <h2>Custom work today. Standardized solutions tomorrow.</h2>
-          <p>
-            Eden Industrial Systems is building toward a product line of practical manufacturing aids, fixture systems, shop accessories, and production tools informed by real customer problems.
-          </p>
-        </div>
-        <div class="product-panel reveal delay-1">
-          <ul>
-            <li>Modular fixture systems</li>
-            <li>Production tooling</li>
-            <li>Shop accessories</li>
-            <li>Manufacturing aids</li>
-          </ul>
-          <p>Early product concepts will be shaped by recurring problems found through engineering and production support work.</p>
-        </div>
-      </div>
-    </section>
+    <section id="products" class="section product-section blueprint-corner"><div class="container product-grid"><div class="section-heading left-heading reveal"><p class="eyebrow">Products in Development</p><h2>Custom work today. Standardized solutions tomorrow.</h2><p>Eden Industrial Systems is building toward a product line of practical manufacturing aids, fixture systems, shop accessories, and production tools informed by real customer problems.</p></div><div class="product-panel reveal delay-1"><ul><li>Modular fixture systems</li><li>Production tooling</li><li>Shop accessories</li><li>Manufacturing aids</li></ul><p>Early product concepts will be shaped by recurring problems found through engineering and production support work.</p></div></div></section>
 
-    <section id="process" class="section process-section blueprint-corner">
-      <div class="container">
-        <div class="section-heading left-heading reveal">
-          <p class="eyebrow">Process</p>
-          <h2>From production problem to usable solution.</h2>
-        </div>
+    <section id="process" class="section process-section blueprint-corner"><div class="container"><div class="section-heading left-heading reveal"><p class="eyebrow">Process</p><h2>From production problem to usable solution.</h2></div><div class="process-line"><article class="process-step reveal"><span>01</span><h3>Understand the Process</h3><p>Review how the part, operator, machine, tool, and workflow interact.</p></article><article class="process-step reveal delay-1"><span>02</span><h3>Find Bottlenecks</h3><p>Identify setup time, wasted motion, quality risks, and production constraints.</p></article><article class="process-step reveal delay-2"><span>03</span><h3>Engineer the Solution</h3><p>Design the fixture, tool, production aid, or mechanical improvement.</p></article><article class="process-step reveal delay-3"><span>04</span><h3>Support Production</h3><p>Prepare drawings, documentation, vendor details, and implementation support.</p></article></div></div></section>
 
-        <div class="process-line">
-          <article class="process-step reveal">
-            <span>01</span>
-            <h3>Understand the Process</h3>
-            <p>Review how the part, operator, machine, tool, and workflow interact.</p>
-          </article>
-          <article class="process-step reveal delay-1">
-            <span>02</span>
-            <h3>Find Bottlenecks</h3>
-            <p>Identify setup time, wasted motion, quality risks, and production constraints.</p>
-          </article>
-          <article class="process-step reveal delay-2">
-            <span>03</span>
-            <h3>Engineer the Solution</h3>
-            <p>Design the fixture, tool, production aid, or mechanical improvement.</p>
-          </article>
-          <article class="process-step reveal delay-3">
-            <span>04</span>
-            <h3>Support Production</h3>
-            <p>Prepare drawings, documentation, vendor details, and implementation support.</p>
-          </article>
-        </div>
-      </div>
-    </section>
+    <section id="resources" class="section muted resource-section"><div class="container"><div class="resource-header reveal"><div class="section-heading left-heading"><p class="eyebrow">Resources</p><h2>Technical articles for manufacturers trying to improve production.</h2><p>Practical guides on setup time, fixture design, workholding, DFM, and production bottlenecks. These resources are written for owners, manufacturing engineers, and production teams that want actionable ideas&mdash;not textbook theory.</p></div><a class="button secondary" href="resources/how-to-reduce-cnc-setup-time.html">Read the First Article</a></div><div class="article-grid reveal delay-1"><article class="article-card featured-article"><p class="eyebrow">Setup Time</p><h3><a href="resources/how-to-reduce-cnc-setup-time.html">How to Reduce CNC Setup Time Without Buying Another Machine</a></h3><p>Setup time is one of the easiest production losses to overlook. This guide explains where time disappears and how fixtures, preparation, and process discipline can improve machine utilization.</p><a class="article-link" href="resources/how-to-reduce-cnc-setup-time.html">Read article &rarr;</a></article><article class="article-card"><p class="eyebrow">Fixture ROI</p><h3>When Does a Custom Fixture Make Financial Sense?</h3><p>How to think about fixture cost, repeat volume, setup savings, scrap reduction, and operator consistency.</p><span class="coming-soon">Coming Soon</span></article><article class="article-card"><p class="eyebrow">Bottlenecks</p><h3>Five Common Causes of Production Bottlenecks</h3><p>A practical look at setup delays, material handling, inspection loops, unclear documentation, and operator-dependent processes.</p><span class="coming-soon">Coming Soon</span></article><article class="article-card"><p class="eyebrow">Fixture Design</p><h3>What Makes a Good Machining Fixture?</h3><p>Good fixtures are not just strong. They are repeatable, accessible, safe, manufacturable, and easy for operators to use.</p><span class="coming-soon">Coming Soon</span></article><article class="article-card"><p class="eyebrow">DFM</p><h3>Design for Manufacturing: Mistakes That Increase Cost</h3><p>Common design choices that make parts harder to machine, inspect, fabricate, or assemble.</p><span class="coming-soon">Coming Soon</span></article></div></div></section>
 
-    <section id="resources" class="section muted resource-section">
-      <div class="container">
-        <div class="resource-header reveal">
-          <div class="section-heading left-heading">
-            <p class="eyebrow">Resources</p>
-            <h2>Technical articles for manufacturers trying to improve production.</h2>
-            <p>
-              Practical guides on setup time, fixture design, workholding, DFM, and production bottlenecks. These resources are written for owners, manufacturing engineers, and production teams that want actionable ideas&mdash;not textbook theory.
-            </p>
-          </div>
-          <a class="button secondary" href="resources/how-to-reduce-cnc-setup-time.html">Read the First Article</a>
-        </div>
+    <section id="about" class="section about-section"><div class="container about-grid"><div class="reveal"><p class="eyebrow">About Eden Industrial Systems</p><h2>Manufacturing-first engineering.</h2><p>Good manufacturing solutions are not the most complicated. They are the ones operators can use consistently, vendors can build, and production teams can trust.</p><p>Eden Industrial Systems combines practical machining experience with mechanical design to create fixtures, tooling, production aids, and product concepts that work in the real world.</p><a class="button secondary" href="#contact">Start a Project</a></div><div class="capability-panel reveal delay-1"><p class="eyebrow">Core Capabilities</p><div class="capability-tags" aria-label="Capabilities"><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path></svg>Fixture Design</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 4l6 6-9 9H5v-6l9-9z"></path><path d="M12 6l6 6"></path></svg>Tooling Design</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 3l8 4v10l-8 4-8-4V7l8-4z"></path><path d="M4 7l8 4 8-4"></path><path d="M12 11v10"></path></svg>DFM Reviews</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 5h16v14H4z"></path><path d="M8 9h8M8 13h5"></path></svg>CAD Design</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path></svg>Production Tooling</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 3h8l4 4v14H7z"></path><path d="M15 3v5h4"></path><path d="M10 13h6M10 17h6"></path></svg>Product Development</span></div></div></div></section>
 
-        <div class="article-grid reveal delay-1">
-          <article class="article-card featured-article">
-            <p class="eyebrow">Setup Time</p>
-            <h3><a href="resources/how-to-reduce-cnc-setup-time.html">How to Reduce CNC Setup Time Without Buying Another Machine</a></h3>
-            <p>
-              Setup time is one of the easiest production losses to overlook. This guide explains where time disappears and how fixtures, preparation, and process discipline can improve machine utilization.
-            </p>
-            <a class="article-link" href="resources/how-to-reduce-cnc-setup-time.html">Read article &rarr;</a>
-          </article>
-
-          <article class="article-card">
-            <p class="eyebrow">Fixture ROI</p>
-            <h3>When Does a Custom Fixture Make Financial Sense?</h3>
-            <p>How to think about fixture cost, repeat volume, setup savings, scrap reduction, and operator consistency.</p>
-            <span class="coming-soon">Coming Soon</span>
-          </article>
-
-          <article class="article-card">
-            <p class="eyebrow">Bottlenecks</p>
-            <h3>Five Common Causes of Production Bottlenecks</h3>
-            <p>A practical look at setup delays, material handling, inspection loops, unclear documentation, and operator-dependent processes.</p>
-            <span class="coming-soon">Coming Soon</span>
-          </article>
-
-          <article class="article-card">
-            <p class="eyebrow">Fixture Design</p>
-            <h3>What Makes a Good Machining Fixture?</h3>
-            <p>Good fixtures are not just strong. They are repeatable, accessible, safe, manufacturable, and easy for operators to use.</p>
-            <span class="coming-soon">Coming Soon</span>
-          </article>
-
-          <article class="article-card">
-            <p class="eyebrow">DFM</p>
-            <h3>Design for Manufacturing: Mistakes That Increase Cost</h3>
-            <p>Common design choices that make parts harder to machine, inspect, fabricate, or assemble.</p>
-            <span class="coming-soon">Coming Soon</span>
-          </article>
-        </div>
-      </div>
-    </section>
-
-    <section id="about" class="section about-section">
-      <div class="container about-grid">
-        <div class="reveal">
-          <p class="eyebrow">About Eden Industrial Systems</p>
-          <h2>Manufacturing-first engineering.</h2>
-          <p>
-            Good manufacturing solutions are not the most complicated. They are the ones operators can use consistently, vendors can build, and production teams can trust.
-          </p>
-          <p>
-            Eden Industrial Systems combines practical machining experience with mechanical design to create fixtures, tooling, production aids, and product concepts that work in the real world.
-          </p>
-          <a class="button secondary" href="#contact">Start a Project</a>
-        </div>
-
-        <div class="capability-panel reveal delay-1">
-          <p class="eyebrow">Core Capabilities</p>
-          <div class="capability-tags" aria-label="Capabilities">
-            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path></svg>Fixture Design</span>
-            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 4l6 6-9 9H5v-6l9-9z"></path><path d="M12 6l6 6"></path></svg>Tooling Design</span>
-            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 3l8 4v10l-8 4-8-4V7l8-4z"></path><path d="M4 7l8 4 8-4"></path><path d="M12 11v10"></path></svg>DFM Reviews</span>
-            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 5h16v14H4z"></path><path d="M8 9h8M8 13h5"></path></svg>CAD Design</span>
-            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path></svg>Production Tooling</span>
-            <span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 3h8l4 4v14H7z"></path><path d="M15 3v5h4"></path><path d="M10 13h6M10 17h6"></path></svg>Product Development</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section id="contact" class="contact-band">
-      <div class="container contact-flow-grid reveal">
-        <div class="contact-primary">
-          <div class="footer-brand">
-            <span class="logo-mark">E</span>
-            <div>
-              <strong>Eden</strong>
-              <small>Industrial Systems</small>
-            </div>
-          </div>
-          <p class="eyebrow">Have a Production Problem?</p>
-          <h2>Send the production issue, not a polished scope.</h2>
-          <p>
-            A useful first conversation can start with a rough drawing, a photo of the setup, or a repeated bottleneck your team wants to remove. Eden Industrial Systems helps turn manufacturing problems into practical fixtures, tooling, process improvements, and mechanical design details.
-          </p>
-          <a class="contact-email" href="mailto:engineering@edenindustrialsystems.com">engineering@edenindustrialsystems.com</a>
-        </div>
-
-        <div class="contact-guidance-grid" aria-label="Contact guidance">
-          <div class="contact-guidance-card">
-            <p class="eyebrow">What to Send</p>
-            <h3>Helpful context for a faster review</h3>
-            <ul class="contact-guidance-list">
-              <li>Part drawings, CAD screenshots, or photos of the current setup.</li>
-              <li>Setup, workholding, fixture, tooling, or inspection pain points.</li>
-              <li>Production volume, repeat frequency, and timeline constraints.</li>
-              <li>What is currently slow, inconsistent, risky, or hard to explain.</li>
-            </ul>
-          </div>
-
-          <div class="contact-guidance-card">
-            <p class="eyebrow">Good Fit</p>
-            <h3>Problems Eden is built to support</h3>
-            <ul class="contact-guidance-list">
-              <li>Setup time, changeover, or bottleneck problems.</li>
-              <li>Repeatability, part-location, or operator-dependent quality issues.</li>
-              <li>DFM, manufacturing drawings, fixture, or tooling backlog.</li>
-              <li>Production aids, workholding concepts, or vendor-ready details.</li>
-            </ul>
-          </div>
-
-          <p class="contact-next-step">
-            <strong>Next step:</strong> send the clearest information you have. A short note with the problem, goal, and available files is enough to start the conversation.
-          </p>
-        </div>
-      </div>
-    </section>
+    <section id="contact" class="contact-band"><div class="container contact-flow-grid reveal"><div class="contact-primary"><div class="footer-brand"><span class="logo-mark">E</span><div><strong>Eden</strong><small>Industrial Systems</small></div></div><p class="eyebrow">Have a Production Problem?</p><h2>Send the production issue, not a polished scope.</h2><p>A useful first conversation can start with a rough drawing, a photo of the setup, or a repeated bottleneck your team wants to remove. Eden Industrial Systems helps turn manufacturing problems into practical fixtures, tooling, process improvements, and mechanical design details.</p><a class="contact-email" href="mailto:engineering@edenindustrialsystems.com">engineering@edenindustrialsystems.com</a></div><div class="contact-guidance-grid" aria-label="Contact guidance"><div class="contact-guidance-card"><p class="eyebrow">What to Send</p><h3>Helpful context for a faster review</h3><ul class="contact-guidance-list"><li>Part drawings, CAD screenshots, or photos of the current setup.</li><li>Setup, workholding, fixture, tooling, or inspection pain points.</li><li>Production volume, repeat frequency, and timeline constraints.</li><li>What is currently slow, inconsistent, risky, or hard to explain.</li></ul></div><div class="contact-guidance-card"><p class="eyebrow">Good Fit</p><h3>Problems Eden is built to support</h3><ul class="contact-guidance-list"><li>Setup time, changeover, or bottleneck problems.</li><li>Repeatability, part-location, or operator-dependent quality issues.</li><li>DFM, manufacturing drawings, fixture, or tooling backlog.</li><li>Production aids, workholding concepts, or vendor-ready details.</li></ul></div><p class="contact-next-step"><strong>Next step:</strong> send the clearest information you have. A short note with the problem, goal, and available files is enough to start the conversation.</p></div></div></section>
   </main>
-
 </body>
 </html>

--- a/manufacturing-engineering-support.html
+++ b/manufacturing-engineering-support.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Manufacturing Engineering Support | Eden Industrial Systems</title>
+  <meta name="description" content="Manufacturing engineering support for production teams that need help with bottlenecks, setup issues, documentation, DFM, fixtures, tooling, and process improvement." />
+  <link rel="canonical" href="https://edenindustrialsystems.com/manufacturing-engineering-support.html" />
+  <meta name="theme-color" content="#063f8f" />
+  <meta property="og:title" content="Manufacturing Engineering Support | Eden Industrial Systems" />
+  <meta property="og:description" content="Practical engineering support for bottlenecks, setup issues, documentation, DFM, fixtures, tooling, and production improvement." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://edenindustrialsystems.com/manufacturing-engineering-support.html" />
+  <meta property="og:site_name" content="Eden Industrial Systems" />
+  <meta property="og:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Manufacturing Engineering Support | Eden Industrial Systems" />
+  <meta name="twitter:description" content="Production-focused engineering support for bottlenecks, setup issues, documentation, DFM, fixtures, and tooling." />
+  <meta name="twitter:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="mobile-nav.css" />
+  <link rel="stylesheet" href="service-pages.css" />
+  <link rel="stylesheet" href="contact-flow.css" />
+  <link rel="stylesheet" href="accessibility.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "name": "Manufacturing Engineering Support",
+    "provider": {"@type": "ProfessionalService", "name": "Eden Industrial Systems", "url": "https://edenindustrialsystems.com/"},
+    "serviceType": "Manufacturing engineering support",
+    "areaServed": "United States",
+    "url": "https://edenindustrialsystems.com/manufacturing-engineering-support.html"
+  }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="index.html" aria-label="Eden Industrial Systems home"><span class="logo-mark">E</span><span><strong>Eden</strong><small>Industrial Systems</small></span></a>
+      <nav class="nav" aria-label="Primary navigation"><a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="nav-button" href="index.html#contact">Contact</a></nav>
+      <a class="mobile-header-contact" href="index.html#contact">Contact</a>
+    </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation"><a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="mobile-nav-contact" href="index.html#contact">Contact</a></nav>
+  </header>
+
+  <main id="main-content">
+    <section class="service-hero blueprint-bg">
+      <div class="container service-hero-grid">
+        <div class="reveal">
+          <a class="breadcrumb" href="index.html#solutions">Back to Solutions</a>
+          <p class="eyebrow">Manufacturing Engineering Support</p>
+          <h1>Extra engineering bandwidth for production problems.</h1>
+          <p class="hero-text">Eden Industrial Systems supports manufacturers that need practical engineering help with bottlenecks, setup time, documentation, DFM, fixtures, tooling, and production workflow issues.</p>
+          <div class="hero-actions"><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Discuss a Production Issue</a><a class="button secondary" href="dfm-review.html">DFM Review</a></div>
+        </div>
+        <aside class="service-summary-card reveal delay-1" aria-label="Manufacturing engineering support summary">
+          <p class="eyebrow">Best Fit</p>
+          <h2>Use engineering support when the team needs practical help now.</h2>
+          <ul class="service-summary-list"><li>Engineering backlog is slowing production.</li><li>Drawings, setup sheets, or process details are unclear.</li><li>A bottleneck needs structured review.</li><li>Existing products need manufacturability support.</li></ul>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container service-page-layout">
+        <div class="service-main-grid">
+          <section class="service-panel">
+            <p class="eyebrow">Problem Statement</p>
+            <h2>Production problems often need focused engineering attention.</h2>
+            <p>Small and mid-sized manufacturers often know exactly where production is struggling, but do not always have spare engineering capacity to document, model, review, or solve the issue.</p>
+            <p>Eden provides manufacturing-first support for the practical details that help teams move from repeated problem to usable solution.</p>
+          </section>
+          <section class="service-panel-grid" aria-label="Manufacturing engineering support details">
+            <div class="service-panel"><p class="eyebrow">Services Included</p><h2>Support can include:</h2><ul class="service-list"><li>Bottleneck and setup-time review.</li><li>Process improvement concepts.</li><li>Manufacturing drawing updates.</li><li>Fixture, tooling, or production aid concepts.</li><li>DFM and manufacturability feedback.</li></ul></div>
+            <div class="service-panel"><p class="eyebrow">Typical Deliverables</p><h2>Clear output your team can act on.</h2><ul class="service-list"><li>CAD models and review packages.</li><li>Manufacturing drawings and notes.</li><li>Issue summaries and recommended next steps.</li><li>Vendor-ready details when needed.</li><li>Implementation and production support notes.</li></ul></div>
+          </section>
+          <section class="service-panel"><p class="eyebrow">Industries Served</p><h2>Support for teams building real products.</h2><ul class="service-chip-list"><li>Precision machining</li><li>Industrial equipment</li><li>Medical device manufacturing</li><li>Aerospace suppliers</li><li>Automation integrators</li><li>Electronics manufacturing</li></ul></section>
+        </div>
+        <aside class="service-sidebar" aria-label="Manufacturing engineering related services">
+          <div class="service-cta-card"><p class="eyebrow">Start Here</p><h2>Need engineering help on a production issue?</h2><p>Send the problem, goal, drawings, photos, and any constraints you already know.</p><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Email Engineering</a></div>
+          <div class="service-cta-card"><p class="eyebrow">Related Services</p><nav class="related-service-links" aria-label="Related service pages"><a href="dfm-review.html">DFM Review <span>&rarr;</span></a><a href="fixture-design.html">Fixture Design <span>&rarr;</span></a><a href="production-tooling.html">Production Tooling <span>&rarr;</span></a></nav></div>
+        </aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/production-tooling.html
+++ b/production-tooling.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Production Tooling | Eden Industrial Systems</title>
+  <meta name="description" content="Production tooling design support for manufacturers that need practical tools, fixtures, aids, and vendor-ready details to improve repeatability and flow." />
+  <link rel="canonical" href="https://edenindustrialsystems.com/production-tooling.html" />
+  <meta name="theme-color" content="#063f8f" />
+  <meta property="og:title" content="Production Tooling | Eden Industrial Systems" />
+  <meta property="og:description" content="Practical production tooling, fixtures, shop aids, and vendor-ready details for manufacturing teams." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://edenindustrialsystems.com/production-tooling.html" />
+  <meta property="og:site_name" content="Eden Industrial Systems" />
+  <meta property="og:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Production Tooling | Eden Industrial Systems" />
+  <meta name="twitter:description" content="Production tooling, fixtures, shop aids, and vendor-ready mechanical design details for manufacturing teams." />
+  <meta name="twitter:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="mobile-nav.css" />
+  <link rel="stylesheet" href="service-pages.css" />
+  <link rel="stylesheet" href="contact-flow.css" />
+  <link rel="stylesheet" href="accessibility.css" />
+  <script type="application/ld+json">
+  {"@context":"https://schema.org","@type":"Service","name":"Production Tooling","provider":{"@type":"ProfessionalService","name":"Eden Industrial Systems","url":"https://edenindustrialsystems.com/"},"serviceType":"Production tooling design","areaServed":"United States","url":"https://edenindustrialsystems.com/production-tooling.html"}
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="index.html" aria-label="Eden Industrial Systems home"><span class="logo-mark">E</span><span><strong>Eden</strong><small>Industrial Systems</small></span></a>
+      <nav class="nav" aria-label="Primary navigation"><a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="nav-button" href="index.html#contact">Contact</a></nav>
+      <a class="mobile-header-contact" href="index.html#contact">Contact</a>
+    </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation"><a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="mobile-nav-contact" href="index.html#contact">Contact</a></nav>
+  </header>
+
+  <main id="main-content">
+    <section class="service-hero blueprint-bg">
+      <div class="container service-hero-grid">
+        <div class="reveal">
+          <a class="breadcrumb" href="index.html#solutions">Back to Solutions</a>
+          <p class="eyebrow">Production Tooling</p>
+          <h1>Tools and production aids designed for real manufacturing constraints.</h1>
+          <p class="hero-text">Eden Industrial Systems designs production tooling, mechanical aids, fixture details, and shop-floor support tools that help teams reduce friction in repeat operations.</p>
+          <div class="hero-actions"><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Discuss Tooling</a><a class="button secondary" href="fixture-design.html">Fixture Design</a></div>
+        </div>
+        <aside class="service-summary-card reveal delay-1" aria-label="Production tooling summary"><p class="eyebrow">Best Fit</p><h2>Use production tooling when repeated manual effort slows output.</h2><ul class="service-summary-list"><li>Operators need a better way to load, hold, move, align, or inspect parts.</li><li>Production needs a tool that vendors can build.</li><li>Material handling or staging slows the process.</li><li>Small mechanical improvements can remove repeated friction.</li></ul></aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container service-page-layout">
+        <div class="service-main-grid">
+          <section class="service-panel"><p class="eyebrow">Problem Statement</p><h2>Production tooling should make the work easier to repeat.</h2><p>Useful production tools are often simple: a loading aid, a guide, a stop, a fixture detail, a small workstation improvement, or a material handling aid that removes repeated wasted motion.</p><p>The design should fit the operator, the part, the floor space, the build method, and the production goal.</p></section>
+          <section class="service-panel-grid" aria-label="Production tooling details">
+            <div class="service-panel"><p class="eyebrow">Services Included</p><h2>Tooling support can include:</h2><ul class="service-list"><li>Production aid and shop tool concepts.</li><li>Assembly, loading, and handling tools.</li><li>Fixture details and tool interfaces.</li><li>Vendor-ready fabrication details.</li><li>Operator access, safety, and maintainability review.</li></ul></div>
+            <div class="service-panel"><p class="eyebrow">Typical Deliverables</p><h2>Practical design output.</h2><ul class="service-list"><li>CAD concepts and review images.</li><li>Fabrication drawings and notes.</li><li>Purchased component references.</li><li>Implementation notes for production use.</li><li>Revision-ready details for future improvements.</li></ul></div>
+          </section>
+          <section class="service-panel"><p class="eyebrow">Industries Served</p><h2>For production environments where repeat work matters.</h2><ul class="service-chip-list"><li>Manufacturing cells</li><li>Assembly operations</li><li>CNC machining</li><li>Material handling</li><li>Inspection support</li><li>Industrial equipment</li></ul></section>
+        </div>
+        <aside class="service-sidebar" aria-label="Production tooling related services"><div class="service-cta-card"><p class="eyebrow">Start Here</p><h2>Need a practical production tool?</h2><p>Send the operation, pain point, constraints, and photos or drawings of the current process.</p><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Email Engineering</a></div><div class="service-cta-card"><p class="eyebrow">Related Services</p><nav class="related-service-links" aria-label="Related service pages"><a href="fixture-design.html">Fixture Design <span>&rarr;</span></a><a href="workholding-design.html">Workholding Design <span>&rarr;</span></a><a href="manufacturing-engineering-support.html">Manufacturing Engineering <span>&rarr;</span></a></nav></div></aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/service-pages.css
+++ b/service-pages.css
@@ -1,0 +1,252 @@
+.service-card-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.service-card-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 38px;
+  padding: 0 14px;
+  border: 1px solid var(--blue);
+  border-radius: 4px;
+  color: var(--blue);
+  font-size: 0.76rem;
+  font-weight: 900;
+  letter-spacing: 0.04em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.service-card-link:hover {
+  background: #f8fbff;
+  color: var(--blue-bright);
+}
+
+.service-hero {
+  padding: 78px 0;
+  border-bottom: 1px solid var(--border);
+  background: linear-gradient(180deg, #ffffff, #f6f8fb);
+}
+
+.service-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) 390px;
+  gap: 48px;
+  align-items: start;
+  position: relative;
+  z-index: 1;
+}
+
+.service-hero h1 {
+  max-width: 900px;
+}
+
+.service-summary-card,
+.service-panel,
+.service-cta-card {
+  background: rgba(255, 255, 255, 0.96);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  box-shadow: 0 14px 34px rgba(6, 26, 56, 0.08);
+}
+
+.service-summary-card {
+  padding: 28px;
+}
+
+.service-summary-card h2,
+.service-panel h2,
+.service-cta-card h2 {
+  font-size: 1.1rem;
+  line-height: 1.2;
+  margin-bottom: 14px;
+}
+
+.service-summary-list,
+.service-list,
+.service-chip-list {
+  list-style: none;
+}
+
+.service-summary-list,
+.service-list {
+  display: grid;
+  gap: 12px;
+}
+
+.service-summary-list li,
+.service-list li {
+  display: grid;
+  grid-template-columns: 18px 1fr;
+  gap: 10px;
+  color: var(--text-muted);
+}
+
+.service-summary-list li::before,
+.service-list li::before {
+  content: "";
+  width: 8px;
+  height: 8px;
+  margin-top: 0.6em;
+  border-radius: 999px;
+  background: var(--blue-bright);
+}
+
+.service-page-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 340px;
+  gap: 34px;
+  align-items: start;
+}
+
+.service-main-grid {
+  display: grid;
+  gap: 20px;
+}
+
+.service-panel {
+  padding: 30px;
+}
+
+.service-panel p {
+  color: var(--text-muted);
+}
+
+.service-panel p + p {
+  margin-top: 14px;
+}
+
+.service-panel-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.service-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.service-chip-list li,
+.service-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 38px;
+  padding: 0 13px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-soft);
+  color: var(--text);
+  font-size: 0.85rem;
+  font-weight: 800;
+}
+
+.service-sidebar {
+  position: sticky;
+  top: 112px;
+  display: grid;
+  gap: 18px;
+}
+
+.service-cta-card {
+  padding: 26px;
+}
+
+.service-cta-card p {
+  color: var(--text-muted);
+  margin-bottom: 20px;
+}
+
+.service-cta-card .button {
+  width: 100%;
+}
+
+.related-service-links {
+  display: grid;
+  gap: 10px;
+}
+
+.related-service-links a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 46px;
+  padding: 10px 14px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text);
+  background: var(--bg-soft);
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.related-service-links a:hover {
+  color: var(--blue-bright);
+  border-color: #b7c5d8;
+  background: #ffffff;
+}
+
+.service-proof-strip {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+  margin-top: 22px;
+}
+
+.service-proof-item {
+  padding: 18px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-soft);
+}
+
+.service-proof-item strong {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--text);
+}
+
+.service-proof-item span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 980px) {
+  .service-hero-grid,
+  .service-page-layout,
+  .service-panel-grid,
+  .service-proof-strip {
+    grid-template-columns: 1fr;
+  }
+
+  .service-sidebar {
+    position: static;
+  }
+}
+
+@media (max-width: 560px) {
+  .service-hero {
+    padding: 56px 0;
+  }
+
+  .service-summary-card,
+  .service-panel,
+  .service-cta-card {
+    padding: 24px;
+  }
+
+  .service-card-links {
+    flex-direction: column;
+  }
+
+  .service-card-link {
+    width: 100%;
+  }
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -7,6 +7,36 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://edenindustrialsystems.com/fixture-design.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://edenindustrialsystems.com/workholding-design.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://edenindustrialsystems.com/manufacturing-engineering-support.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://edenindustrialsystems.com/dfm-review.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://edenindustrialsystems.com/production-tooling.html</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://edenindustrialsystems.com/resources/how-to-reduce-cnc-setup-time.html</loc>
     <lastmod>2026-06-27</lastmod>
     <changefreq>monthly</changefreq>

--- a/workholding-design.html
+++ b/workholding-design.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Workholding Design | Eden Industrial Systems</title>
+  <meta name="description" content="Workholding design support for manufacturers that need repeatable part location, stable clamping, tool access, and practical CNC setup improvements." />
+  <link rel="canonical" href="https://edenindustrialsystems.com/workholding-design.html" />
+  <meta name="theme-color" content="#063f8f" />
+  <meta property="og:title" content="Workholding Design | Eden Industrial Systems" />
+  <meta property="og:description" content="Practical workholding concepts for repeatable part location, stable clamping, tool access, and setup improvement." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://edenindustrialsystems.com/workholding-design.html" />
+  <meta property="og:site_name" content="Eden Industrial Systems" />
+  <meta property="og:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Workholding Design | Eden Industrial Systems" />
+  <meta name="twitter:description" content="Workholding concepts for repeatable part location, stable clamping, tool access, and setup improvement." />
+  <meta name="twitter:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
+  <link rel="manifest" href="/site.webmanifest" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=Sora:wght@600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css" />
+  <link rel="stylesheet" href="mobile-nav.css" />
+  <link rel="stylesheet" href="service-pages.css" />
+  <link rel="stylesheet" href="contact-flow.css" />
+  <link rel="stylesheet" href="accessibility.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "name": "Workholding Design",
+    "provider": {"@type": "ProfessionalService", "name": "Eden Industrial Systems", "url": "https://edenindustrialsystems.com/"},
+    "serviceType": "Workholding design",
+    "areaServed": "United States",
+    "url": "https://edenindustrialsystems.com/workholding-design.html"
+  }
+  </script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to main content</a>
+  <header class="site-header">
+    <div class="container header-inner">
+      <a class="logo" href="index.html" aria-label="Eden Industrial Systems home"><span class="logo-mark">E</span><span><strong>Eden</strong><small>Industrial Systems</small></span></a>
+      <nav class="nav" aria-label="Primary navigation">
+        <a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="nav-button" href="index.html#contact">Contact</a>
+      </nav>
+      <a class="mobile-header-contact" href="index.html#contact">Contact</a>
+    </div>
+    <nav class="mobile-nav" aria-label="Mobile navigation">
+      <a href="index.html#problems">Problems</a><a href="index.html#solutions">Solutions</a><a href="index.html#work">Projects</a><a href="index.html#products">Products</a><a href="index.html#resources">Resources</a><a class="mobile-nav-contact" href="index.html#contact">Contact</a>
+    </nav>
+  </header>
+
+  <main id="main-content">
+    <section class="service-hero blueprint-bg">
+      <div class="container service-hero-grid">
+        <div class="reveal">
+          <a class="breadcrumb" href="index.html#solutions">Back to Solutions</a>
+          <p class="eyebrow">Workholding Design</p>
+          <h1>Workholding concepts that make setup and loading more repeatable.</h1>
+          <p class="hero-text">Eden Industrial Systems helps manufacturers think through part location, clamping, tool access, chip clearance, and operator workflow before workholding problems slow production.</p>
+          <div class="hero-actions">
+            <a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Discuss Workholding</a>
+            <a class="button secondary" href="fixture-design.html">Fixture Design</a>
+          </div>
+        </div>
+        <aside class="service-summary-card reveal delay-1" aria-label="Workholding design summary">
+          <p class="eyebrow">Best Fit</p>
+          <h2>Use workholding design when clamping or location is driving variation.</h2>
+          <ul class="service-summary-list">
+            <li>Manual adjustment slows every setup.</li>
+            <li>Clamping blocks cutting, probing, or inspection.</li>
+            <li>Parts shift, rock, distort, or load inconsistently.</li>
+            <li>Repeat jobs need more predictable first-piece approval.</li>
+          </ul>
+        </aside>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container service-page-layout">
+        <div class="service-main-grid">
+          <section class="service-panel">
+            <p class="eyebrow">Problem Statement</p>
+            <h2>Workholding should support the process, not fight it.</h2>
+            <p>Good workholding balances location, clamping force, tool access, chip management, part protection, and inspection needs. It is not just about holding tighter; it is about holding the right way for the operation.</p>
+            <p>Eden reviews how the part is loaded, where the datums are, how forces move through the setup, and where operators lose time adjusting or checking the work.</p>
+          </section>
+          <section class="service-panel-grid" aria-label="Workholding design details">
+            <div class="service-panel">
+              <p class="eyebrow">Services Included</p>
+              <h2>Workholding support can include:</h2>
+              <ul class="service-list">
+                <li>Soft jaw and fixture plate concepts.</li>
+                <li>Part nesting, stop, and datum strategy.</li>
+                <li>Clamp layout and access review.</li>
+                <li>Tool, probe, chip, and inspection clearance review.</li>
+                <li>Repeat setup and part-family workholding concepts.</li>
+              </ul>
+            </div>
+            <div class="service-panel">
+              <p class="eyebrow">Typical Deliverables</p>
+              <h2>Buildable concepts and documentation.</h2>
+              <ul class="service-list">
+                <li>Workholding concept CAD or sketches.</li>
+                <li>Soft jaw, nest, stop, or plate details.</li>
+                <li>Vendor-ready drawings when needed.</li>
+                <li>Setup notes and operator considerations.</li>
+                <li>Purchased component and hardware references.</li>
+              </ul>
+            </div>
+          </section>
+          <section class="service-panel">
+            <p class="eyebrow">Industries Served</p>
+            <h2>Useful anywhere part location matters.</h2>
+            <ul class="service-chip-list"><li>CNC machining</li><li>Assembly operations</li><li>Inspection fixtures</li><li>Prototype builds</li><li>Repeat production</li><li>Small and mid-sized manufacturers</li></ul>
+          </section>
+        </div>
+        <aside class="service-sidebar" aria-label="Workholding related services">
+          <div class="service-cta-card"><p class="eyebrow">Start Here</p><h2>Have a clamping or location problem?</h2><p>Send a setup photo, part drawing, or recurring workholding issue and the goal you want to reach.</p><a class="button primary" href="mailto:engineering@edenindustrialsystems.com">Email Engineering</a></div>
+          <div class="service-cta-card"><p class="eyebrow">Related Services</p><nav class="related-service-links" aria-label="Related service pages"><a href="fixture-design.html">Fixture Design <span>&rarr;</span></a><a href="production-tooling.html">Production Tooling <span>&rarr;</span></a><a href="manufacturing-engineering-support.html">Manufacturing Engineering <span>&rarr;</span></a></nav></div>
+        </aside>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds dedicated service pages for fixture design, workholding design, manufacturing engineering support, DFM review, and production tooling.
- Adds `service-pages.css` for reusable service page layouts, homepage service-card links, related service navigation, CTA cards, deliverables, industries, and responsive behavior.
- Links the new service pages from the homepage Solutions cards without adding a large new homepage section.
- Updates `sitemap.xml` with all new service page URLs.

## Verification
- Confirmed each service page includes a clear headline, problem statement, services included, typical deliverables, industries served, and a contact CTA.
- Confirmed homepage Solutions cards link to all five service pages.
- Confirmed sitemap includes the homepage, all five service pages, and the CNC setup-time article.