### PR TITLE
Add lightweight trust signals

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
   <link rel="stylesheet" href="mobile-nav.css" />
   <link rel="stylesheet" href="project-cases.css" />
   <link rel="stylesheet" href="service-pages.css" />
+  <link rel="stylesheet" href="trust-signals.css" />
   <link rel="stylesheet" href="contact-flow.css" />
   <link rel="stylesheet" href="accessibility.css" />
   <script type="application/ld+json">
@@ -96,6 +97,23 @@
         <article class="outcome-item reveal delay-1"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M4 19h16"></path><path d="M7 16l4-5 3 3 5-8"></path><path d="M15 6h4v4"></path></svg></span><div><h2>Increase Throughput</h2><p>Remove bottlenecks that limit production flow and capacity.</p></div></article>
         <article class="outcome-item reveal delay-2"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 5-3 8-7 10-4-2-7-5-7-10V6l7-3z"></path><path d="M8.5 12l2.2 2.2 4.8-5"></path></svg></span><div><h2>Improve Repeatability</h2><p>Reduce variation from part location, operator adjustment, and manual handling.</p></div></article>
         <article class="outcome-item reveal delay-3"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 7v5l3 2"></path></svg></span><div><h2>Support Production</h2><p>Provide practical CAD, drawings, and vendor-ready details.</p></div></article>
+      </div>
+    </section>
+
+    <section class="trust-strip" aria-label="Why manufacturers work with Eden Industrial Systems">
+      <div class="container trust-strip-grid">
+        <div class="trust-intro reveal">
+          <p class="eyebrow">Why Eden</p>
+          <h2>Manufacturing-first engineering support.</h2>
+          <p>These are practical credibility signals, not inflated claims: the work is focused on buildable design, usable documentation, operator-friendly tooling, and production problems that need clear next steps.</p>
+        </div>
+        <div class="trust-signal-grid reveal delay-1">
+          <article class="trust-signal"><span>01</span><h3>Manufacturing-first design</h3><p>Design decisions are reviewed against setup, loading, clamping, tool access, inspection, vendor buildability, and how the solution will actually be used.</p></article>
+          <article class="trust-signal"><span>02</span><h3>Vendor-ready documentation</h3><p>Projects can include CAD models, drawings, notes, and details intended to help suppliers quote, fabricate, review, and build with less ambiguity.</p></article>
+          <article class="trust-signal"><span>03</span><h3>Operator-friendly tooling</h3><p>Fixture and tooling concepts consider reach, loading sequence, repeatability, maintenance access, and the decisions operators need to make during real production.</p></article>
+          <article class="trust-signal"><span>04</span><h3>CAD and drawing support</h3><p>Support can range from concept layouts to manufacturing drawings, DFM notes, setup documentation, and practical mechanical design details.</p></article>
+          <article class="trust-signal trust-signal-wide"><span>05</span><h3>Production-focused problem solving</h3><p>The goal is not just clean CAD. The goal is a usable improvement that helps reduce setup friction, clarify manufacturing intent, or move a repeated production problem toward a buildable solution.</p></article>
+        </div>
       </div>
     </section>
 

--- a/trust-signals.css
+++ b/trust-signals.css
@@ -1,0 +1,107 @@
+.trust-strip {
+  padding: 58px 0;
+  background: linear-gradient(180deg, #ffffff, var(--bg-soft));
+  border-bottom: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+}
+
+.trust-strip::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(rgba(6, 63, 143, 0.045) 1px, transparent 1px), linear-gradient(90deg, rgba(6, 63, 143, 0.045) 1px, transparent 1px);
+  background-size: 34px 34px;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.trust-strip-grid {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 0.85fr 1.15fr;
+  gap: 40px;
+  align-items: start;
+}
+
+.trust-intro h2 {
+  font-size: clamp(1.9rem, 3vw, 2.8rem);
+  line-height: 1.08;
+  letter-spacing: -0.04em;
+  margin-bottom: 14px;
+}
+
+.trust-intro p {
+  color: var(--text-muted);
+  font-size: 1.02rem;
+}
+
+.trust-signal-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.trust-signal {
+  min-height: 164px;
+  padding: 22px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 12px 28px rgba(6, 26, 56, 0.06);
+}
+
+.trust-signal span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 16px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--blue);
+  background: #eef5ff;
+  font-size: 0.74rem;
+  font-weight: 900;
+}
+
+.trust-signal h3 {
+  margin-bottom: 8px;
+  font-size: 1.05rem;
+  line-height: 1.2;
+}
+
+.trust-signal p {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.trust-signal-wide {
+  grid-column: 1 / -1;
+  min-height: 0;
+}
+
+@media (max-width: 920px) {
+  .trust-strip-grid,
+  .trust-signal-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .trust-signal-wide {
+    grid-column: auto;
+  }
+}
+
+@media (max-width: 560px) {
+  .trust-strip {
+    padding: 46px 0;
+  }
+
+  .trust-signal {
+    min-height: 0;
+    padding: 20px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a lightweight Why Eden trust-signal strip near the top of the homepage.
- Adds truthful credibility points around manufacturing-first design, vendor-ready documentation, operator-friendly tooling, CAD and drawing support, and production-focused problem solving.
- Adds `trust-signals.css` for responsive styling consistent with the existing industrial/blueprint visual system.
- Avoids unsupported metrics, certifications, or claims.

## Verification
- Confirmed the homepage links `trust-signals.css`.
- Confirmed the new trust strip appears after the outcome strip and before the Common Problems section.
- Confirmed trust language stays practical and non-inflated.