### PR TITLE
Remove resources and refine fixture service homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,15 +8,14 @@
   <link rel="canonical" href="https://edenindustrialsystems.com/" />
   <meta name="theme-color" content="#063f8f" />
   <meta property="og:title" content="Multi-Part CNC Fixture Design | Eden Industrial Systems" />
-  <meta property="og:description" content="Eden Industrial Systems designs multi-part CNC fixtures for high-mix production shops that want to reduce setup time, improve repeatability, and increase throughput." />
+  <meta property="og:description" content="Multi-part CNC fixture design for high-mix production shops that need faster setup, better repeatability, and more throughput." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://edenindustrialsystems.com/" />
   <meta property="og:site_name" content="Eden Industrial Systems" />
   <meta property="og:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
-  <meta property="og:image:alt" content="Eden Industrial Systems multi-part CNC fixture design social preview" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Multi-Part CNC Fixture Design | Eden Industrial Systems" />
-  <meta name="twitter:description" content="Eden Industrial Systems designs multi-part CNC fixtures for high-mix production shops that want to reduce setup time, improve repeatability, and increase throughput." />
+  <meta name="twitter:description" content="Multi-part CNC fixture design for high-mix production shops." />
   <meta name="twitter:image" content="https://edenindustrialsystems.com/assets/eden-og-image.svg" />
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml" />
   <link rel="manifest" href="/site.webmanifest" />
@@ -30,45 +29,17 @@
   <link rel="stylesheet" href="trust-signals.css" />
   <link rel="stylesheet" href="contact-flow.css" />
   <link rel="stylesheet" href="accessibility.css" />
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "ProfessionalService",
-    "name": "Eden Industrial Systems",
-    "url": "https://edenindustrialsystems.com/",
-    "email": "engineering@edenindustrialsystems.com",
-    "description": "Multi-part CNC fixture design for high-mix production shops that want to reduce setup time, improve repeatability, and increase throughput.",
-    "areaServed": "United States",
-    "serviceType": ["Multi-part CNC fixture design", "CNC workholding design", "Fixture plates", "Soft jaw strategies", "Setup time reduction", "Build-ready fixture documentation"],
-    "knowsAbout": ["Multi-part fixture design", "CNC workholding", "CNC setup time reduction", "Fixture plates", "Soft jaws", "Datum control", "Repeatable loading", "High-mix CNC production"]
-  }
-  </script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to main content</a>
 
   <header class="site-header">
     <div class="container header-inner">
-      <a class="logo" href="#" aria-label="Eden Industrial Systems home">
-        <span class="logo-mark">E</span>
-        <span><strong>Eden</strong><small>Industrial Systems</small></span>
-      </a>
-      <nav class="nav" aria-label="Primary navigation">
-        <a href="fixture-design.html">Fixture Design</a>
-        <a href="#process">Process</a>
-        <a href="#work">Examples</a>
-        <a href="#resources">Resources</a>
-        <a class="nav-button" href="#contact">Contact</a>
-      </nav>
+      <a class="logo" href="#" aria-label="Eden Industrial Systems home"><span class="logo-mark">E</span><span><strong>Eden</strong><small>Industrial Systems</small></span></a>
+      <nav class="nav" aria-label="Primary navigation"><a href="fixture-design.html">Fixture Design</a><a href="#process">Process</a><a href="#work">Examples</a><a class="nav-button" href="#contact">Contact</a></nav>
       <a class="mobile-header-contact" href="#contact">Contact</a>
     </div>
-    <nav class="mobile-nav" aria-label="Mobile navigation">
-      <a href="fixture-design.html">Fixture Design</a>
-      <a href="#process">Process</a>
-      <a href="#work">Examples</a>
-      <a href="#resources">Resources</a>
-      <a class="mobile-nav-contact" href="#contact">Contact</a>
-    </nav>
+    <nav class="mobile-nav" aria-label="Mobile navigation"><a href="fixture-design.html">Fixture Design</a><a href="#process">Process</a><a href="#work">Examples</a><a class="mobile-nav-contact" href="#contact">Contact</a></nav>
   </header>
 
   <main id="main-content">
@@ -78,101 +49,66 @@
           <p class="eyebrow">CNC Fixture Design &bull; Multi-Part Workholding &bull; Setup Time Reduction</p>
           <h1>Multi-Part CNC Fixture Design for High-Mix Production Shops</h1>
           <p class="hero-text">Eden Industrial Systems designs practical CNC fixtures that help OEMs and machine shops reduce setup time, load multiple parts per cycle, improve repeatability, and increase throughput without buying another machine.</p>
-          <div class="hero-actions">
-            <a class="button primary" href="mailto:engineering@edenindustrialsystems.com?subject=Fixture%20Review">Request a Fixture Review</a>
-            <a class="button secondary" href="#process">See Fixture Design Process</a>
-          </div>
+          <div class="hero-actions"><a class="button primary" href="mailto:engineering@edenindustrialsystems.com?subject=Fixture%20Review">Request a Fixture Review</a><a class="button secondary" href="#process">See Fixture Design Process</a></div>
         </div>
-        <figure class="hero-visual reveal delay-1">
-          <img src="assets/hero-manufacturing-systems.svg" alt="CAD-style fixture, tooling, and production workflow illustration" />
-        </figure>
+        <figure class="hero-visual reveal delay-1"><img src="assets/hero-manufacturing-systems.svg" alt="CAD-style fixture and production workflow illustration" /></figure>
       </div>
     </section>
 
-    <section class="outcome-strip" aria-label="Engineering outcomes">
+    <section class="outcome-strip" aria-label="Fixture design outcomes">
       <div class="container outcome-grid">
-        <article class="outcome-item reveal"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 2v4M12 18v4M2 12h4M18 12h4"></path></svg></span><div><h2>Run More Parts Per Setup</h2><p>Multi-part fixtures help turn repeated one-at-a-time handling into more productive machine cycles.</p></div></article>
-        <article class="outcome-item reveal delay-1"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M4 19V5"></path><path d="M4 19h16"></path><path d="M7 16l4-5 3 3 5-8"></path><path d="M15 6h4v4"></path></svg></span><div><h2>Reduce Changeover Time</h2><p>Dedicated locating, clamping, and repeatable mounting reduce indicating, adjusting, and first-piece delays.</p></div></article>
-        <article class="outcome-item reveal delay-2"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 5-3 8-7 10-4-2-7-5-7-10V6l7-3z"></path><path d="M8.5 12l2.2 2.2 4.8-5"></path></svg></span><div><h2>Improve Part-to-Part Consistency</h2><p>Positive datums, controlled clamping, and repeatable loading reduce operator-dependent variation.</p></div></article>
-        <article class="outcome-item reveal delay-3"><span class="outcome-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="8"></circle><path d="M12 7v5l3 2"></path></svg></span><div><h2>Get Build-Ready Fixture Details</h2><p>Receive CAD models, drawings, hardware references, and setup notes your shop or vendor can use.</p></div></article>
+        <article class="outcome-item reveal"><div><h2>Run More Parts Per Setup</h2><p>Multi-part fixtures turn repeated one-at-a-time handling into more productive machine cycles.</p></div></article>
+        <article class="outcome-item reveal delay-1"><div><h2>Reduce Changeover Time</h2><p>Dedicated locating, clamping, and repeatable mounting reduce indicating, adjusting, and first-piece delays.</p></div></article>
+        <article class="outcome-item reveal delay-2"><div><h2>Improve Repeatability</h2><p>Positive datums, controlled clamping, and repeatable loading reduce operator-dependent variation.</p></div></article>
+        <article class="outcome-item reveal delay-3"><div><h2>Get Build-Ready Details</h2><p>Receive CAD models, drawings, hardware references, and setup notes your shop or vendor can use.</p></div></article>
       </div>
     </section>
 
     <section class="trust-strip" aria-label="Why manufacturers work with Eden Industrial Systems">
       <div class="container trust-strip-grid">
-        <div class="trust-intro reveal">
-          <p class="eyebrow">Why Eden</p>
-          <h2>Machining-first fixture design support.</h2>
-          <p>Fixture design has to work on the machine, not just on a screen. Eden Industrial Systems focuses on practical workholding that considers setup, loading, clamping, tool access, chip clearance, and repeatable use by operators.</p>
-        </div>
+        <div class="trust-intro reveal"><p class="eyebrow">Why Eden</p><h2>Machining-first fixture design support.</h2><p>Fixture design has to work on the machine, not just on a screen. Eden Industrial Systems focuses on practical workholding that considers setup, loading, clamping, tool access, chip clearance, and repeatable operator use.</p></div>
         <div class="trust-signal-grid reveal delay-1">
-          <article class="trust-signal"><span>01</span><h3>Shop-floor perspective</h3><p>Fixture decisions are reviewed against how the part is actually loaded, clamped, cut, inspected, and repeated in production.</p></article>
-          <article class="trust-signal"><span>02</span><h3>Build-ready documentation</h3><p>Projects can include CAD models, drawings, hardware references, and notes your shop or outside vendor can use to quote and build.</p></article>
-          <article class="trust-signal"><span>03</span><h3>Operator-friendly loading</h3><p>Concepts consider reach, loading sequence, clamp access, part seating, and the decisions operators need to make every cycle.</p></article>
+          <article class="trust-signal"><span>01</span><h3>Shop-floor perspective</h3><p>Fixture decisions are reviewed against how the part is loaded, clamped, cut, inspected, and repeated in production.</p></article>
+          <article class="trust-signal"><span>02</span><h3>Build-ready documentation</h3><p>Projects can include CAD models, drawings, hardware references, and notes your shop or vendor can use to quote and build.</p></article>
+          <article class="trust-signal"><span>03</span><h3>Operator-friendly loading</h3><p>Concepts consider reach, loading sequence, clamp access, part seating, and cycle-to-cycle repeatability.</p></article>
           <article class="trust-signal"><span>04</span><h3>Repeatable datum control</h3><p>The design approach focuses on controlled location, positive stops, consistent clamping, and setup details that reduce variation.</p></article>
-          <article class="trust-signal trust-signal-wide"><span>05</span><h3>Throughput-focused problem solving</h3><p>The goal is a usable fixture strategy that reduces setup friction, supports multi-part loading, and helps high-mix repeat work run more predictably.</p></article>
-        </div>
-      </div>
-    </section>
-
-    <section id="problems" class="section blueprint-corner">
-      <div class="container problem-grid">
-        <div class="section-heading left-heading reveal">
-          <p class="eyebrow">Common Fixture Problems</p>
-          <h2>Is setup time limiting your repeat CNC work?</h2>
-          <p>The right CNC fixture can make repeat parts easier to locate, load, clamp, inspect, and run consistently across setups.</p>
-        </div>
-        <div class="problem-list reveal delay-1">
-          <span>Long CNC setup times</span><span>One-at-a-time part loading</span><span>Operator-dependent clamping</span><span>Inconsistent part location</span><span>Slow first-piece approval</span><span>Poor datum control</span><span>Clamp or tool-access issues</span><span>Bottleneck machines</span>
         </div>
       </div>
     </section>
 
     <section id="solutions" class="section muted blueprint-bg-soft">
       <div class="container">
-        <div class="section-heading left-heading reveal">
-          <p class="eyebrow">Focused Service</p>
-          <h2>One Focused Service: Multi-Part CNC Fixture Design</h2>
-          <p>Eden Industrial Systems helps CNC shops and OEM manufacturers design practical fixtures for repeat production parts. The goal is to reduce setup friction, improve loading, control part location, and make high-mix repeat work easier to run.</p>
-        </div>
+        <div class="section-heading left-heading reveal"><p class="eyebrow">Focused Service</p><h2>Good-fit fixture design projects.</h2><p>Eden Industrial Systems is built for shops and OEMs that already understand their production issue and need practical fixture design support to make repeat work faster, more consistent, and easier to load.</p></div>
         <div class="cards service-cards">
-          <article class="card reveal">
-            <span class="card-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path><path d="M14 11h5"></path><path d="M14 15h5"></path></svg></span>
-            <h3>Best-Fit Projects</h3>
-            <ul><li>Repeat CNC parts with long setup times.</li><li>Parts currently loaded one at a time.</li><li>Families of parts that could share a fixture base.</li><li>Jobs with too much indicating, nudging, clamping adjustment, or first-piece inspection delay.</li><li>Bottleneck machines where setup time limits weekly output.</li></ul>
-          </article>
-          <article class="card reveal delay-1">
-            <span class="card-icon" aria-hidden="true"><svg viewBox="0 0 24 24"><path d="M12 3l7 3v5c0 5-3 8-7 10-4-2-7-5-7-10V6l7-3z"></path><path d="M8.5 12l2.2 2.2 4.8-5"></path></svg></span>
-            <h3>Not the Best Fit</h3>
-            <ul><li>One-off prototype jobs.</li><li>Extremely low-repeat parts.</li><li>Shops looking only for cheap CAD drafting.</li><li>Fixtures with no available part drawing, setup photo, or process context.</li></ul>
-          </article>
+          <article class="card reveal"><h3>Multi-Part CNC Fixtures</h3><ul><li>Repeat parts currently loaded one at a time.</li><li>Jobs where more parts per cycle would improve spindle utilization.</li><li>VMC, HMC, lathe, and mill-turn fixture concepts.</li></ul></article>
+          <article class="card reveal delay-1"><h3>Part-Family Fixtures</h3><ul><li>Related parts that share datums, clamp zones, or tool access needs.</li><li>Modular bases with replaceable nests, stops, or details.</li><li>Repeat setups where changeover consistency matters.</li></ul></article>
+          <article class="card reveal delay-2"><h3>Soft Jaws, Stops, and Locating Strategy</h3><ul><li>Jobs that rely too much on operator feel.</li><li>Parts that need clearer seating, stops, or datum control.</li><li>Workholding details that improve repeatability without overbuilding the fixture.</li></ul></article>
+          <article class="card reveal delay-3"><h3>Build-Ready Fixture Documentation</h3><ul><li>3D fixture models and drawings.</li><li>Purchased clamp and hardware references.</li><li>Setup notes your shop or vendor can use to quote, build, and run the fixture.</li></ul></article>
         </div>
       </div>
     </section>
 
     <section id="industries" class="section industries-section">
       <div class="container">
-        <div class="section-heading left-heading reveal"><p class="eyebrow">Industries</p><h2>Built for shops and OEMs with repeat CNC work.</h2></div>
+        <div class="section-heading left-heading reveal"><p class="eyebrow">Industries Served</p></div>
         <div class="industry-grid reveal delay-1"><span>Precision Machining</span><span>OEM Production</span><span>Medical Components</span><span>Aerospace Suppliers</span><span>Industrial Equipment</span><span>High-Mix CNC Shops</span></div>
       </div>
     </section>
 
     <section id="work" class="section muted blueprint-bg-soft">
       <div class="container">
-        <div class="section-heading left-heading reveal"><p class="eyebrow">Fixture Examples</p><h2>Fixture concepts focused on setup time, repeatability, and throughput.</h2><p>These examples show the type of CNC fixture problems Eden Industrial Systems is focused on solving. They are written as practical project types, not inflated case studies or guaranteed results.</p></div>
+        <div class="section-heading left-heading reveal"><p class="eyebrow">Fixture Examples</p><h2>Fixture concepts focused on setup time, repeatability, and throughput.</h2><p>These examples show the type of CNC fixture problems Eden Industrial Systems is focused on solving. They are practical project types, not inflated case studies or guaranteed results.</p></div>
         <div class="project-grid reveal delay-1">
-          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style multi-part machining fixture with locating pins, clamps, and datum references" /><div class="project-copy"><p class="eyebrow">Multi-Part Workholding</p><h3>Multi-Part VMC Fixture Concept</h3><p>For repeat milled parts where one-at-a-time loading limits throughput.</p><div class="case-study-list" aria-label="Multi-part VMC fixture concept details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">A repeat milled part is being loaded one at a time, limiting throughput and increasing operator handling.</span></div><div class="case-study-item"><span class="case-study-label">Fixture Approach</span><span class="case-study-text">Design a multi-part fixture that controls part location, improves clamp access, and allows multiple parts to be loaded per cycle.</span></div><div class="case-study-item"><span class="case-study-label">Expected Result</span><span class="case-study-text">Less handling per part, better repeatability, and more productive machine cycles.</span></div></div></div></article>
-          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style modular fixture base plate with replaceable details and common datum features" /><div class="project-copy"><p class="eyebrow">Part-Family Fixtures</p><h3>Family Fixture / Modular Base Plate</h3><p>For similar part families where common datums and replaceable details can reduce changeover.</p><div class="case-study-list" aria-label="Family fixture and modular base plate details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">A shop runs similar part families but loses time changing setups between related jobs.</span></div><div class="case-study-item"><span class="case-study-label">Fixture Approach</span><span class="case-study-text">Design a shared fixture base with replaceable details, common datums, and repeatable mounting locations.</span></div><div class="case-study-item"><span class="case-study-label">Expected Result</span><span class="case-study-text">Faster changeovers between part families and more consistent setup results.</span></div></div><a class="case-study-link" href="#contact">Discuss a fixture project &rarr;</a></div></article>
-          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style soft jaw and stop strategy for repeatable CNC part loading" /><div class="project-copy"><p class="eyebrow">Repeatable Loading</p><h3>Soft Jaw + Stop Strategy</h3><p>For lathe or mill jobs where location depends too much on operator feel.</p><div class="case-study-list" aria-label="Soft jaw and stop strategy details"><div class="case-study-item"><span class="case-study-label">Problem</span><span class="case-study-text">A lathe or mill operation depends too much on operator feel, inconsistent part seating, or manual adjustment.</span></div><div class="case-study-item"><span class="case-study-label">Fixture Approach</span><span class="case-study-text">Design soft jaws, stops, nests, or simple locating features that make the loading process more repeatable.</span></div><div class="case-study-item"><span class="case-study-label">Expected Result</span><span class="case-study-text">More consistent part location, less operator decision-making, and faster first-piece approval.</span></div></div><a class="case-study-link" href="#contact">Discuss a fixture project &rarr;</a></div></article>
+          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style multi-part machining fixture" /><div class="project-copy"><p class="eyebrow">Multi-Part Workholding</p><h3>Multi-Part VMC Fixture Concept</h3><p>A fixture concept for repeat milled parts where one-at-a-time loading limits throughput.</p></div></article>
+          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style modular fixture base plate" /><div class="project-copy"><p class="eyebrow">Part-Family Fixtures</p><h3>Family Fixture / Modular Base Plate</h3><p>A shared base fixture strategy for related part families with common datums or clamp zones.</p><a class="case-study-link" href="#contact">Discuss a fixture project &rarr;</a></div></article>
+          <article class="project-card large-project"><img src="assets/project-fixture-system.svg" alt="CAD-style soft jaw and stop strategy" /><div class="project-copy"><p class="eyebrow">Repeatable Loading</p><h3>Soft Jaw + Stop Strategy</h3><p>Soft jaw, stop, and datum concepts for lathe or mill jobs where loading consistency matters.</p><a class="case-study-link" href="#contact">Discuss a fixture project &rarr;</a></div></article>
         </div>
       </div>
     </section>
 
-    <section id="process" class="section process-section blueprint-corner"><div class="container"><div class="section-heading left-heading reveal"><p class="eyebrow">Process</p><h2>From fixture problem to build-ready design.</h2></div><div class="process-line"><article class="process-step reveal"><span>01</span><h3>Review the Current Setup</h3><p>Review part drawings, machine type, current workholding, setup photos, cycle requirements, pain points, and production volume.</p></article><article class="process-step reveal delay-1"><span>02</span><h3>Identify Fixture Opportunity</h3><p>Look for repeated indicating, slow loading, unnecessary operator decisions, poor datum control, clamp access problems, and multi-part loading potential.</p></article><article class="process-step reveal delay-2"><span>03</span><h3>Design the Fixture Concept</h3><p>Develop a practical fixture strategy around locating, clamping, tool access, chip clearance, probing, inspection, and operator loading.</p></article><article class="process-step reveal delay-3"><span>04</span><h3>Deliver Build-Ready Details</h3><p>Provide CAD, drawings, purchased component references, setup notes, and vendor-ready documentation when needed.</p></article></div></div></section>
+    <section id="process" class="section process-section blueprint-corner"><div class="container"><div class="section-heading left-heading reveal"><p class="eyebrow">Process</p><h2>From fixture problem to build-ready design.</h2></div><div class="process-line"><article class="process-step reveal"><span>01</span><h3>Review the Current Setup</h3><p>Review part drawings, machine type, current workholding, setup photos, cycle requirements, pain points, and production volume.</p></article><article class="process-step reveal delay-1"><span>02</span><h3>Identify Fixture Opportunity</h3><p>Look for repeated indicating, slow loading, poor datum control, clamp access problems, and multi-part loading potential.</p></article><article class="process-step reveal delay-2"><span>03</span><h3>Design the Fixture Concept</h3><p>Develop a practical fixture strategy around locating, clamping, tool access, chip clearance, probing, inspection, and operator loading.</p></article><article class="process-step reveal delay-3"><span>04</span><h3>Deliver Build-Ready Details</h3><p>Provide CAD, drawings, purchased component references, setup notes, and vendor-ready documentation when needed.</p></article></div></div></section>
 
-    <section id="resources" class="section muted resource-section"><div class="container"><div class="resource-header reveal"><div class="section-heading left-heading"><p class="eyebrow">Resources</p><h2>Practical fixture and setup-time articles for CNC shops.</h2><p>Focused guides on CNC setup time, multi-part fixtures, workholding choices, fixture ROI, and repeatable loading for high-mix production shops.</p></div><a class="button secondary" href="resources/how-to-reduce-cnc-setup-time.html">Read Setup Time Guide</a></div><div class="article-grid reveal delay-1"><article class="article-card featured-article"><p class="eyebrow">Setup Time</p><h3><a href="resources/how-to-reduce-cnc-setup-time.html">How to Reduce CNC Setup Time Without Buying Another Machine</a></h3><p>Setup time is one of the easiest production losses to overlook. This guide explains where time disappears and how fixtures, preparation, and process discipline can improve machine utilization.</p><a class="article-link" href="resources/how-to-reduce-cnc-setup-time.html">Read article &rarr;</a></article><article class="article-card"><p class="eyebrow">Fixture ROI</p><h3>When Does a Multi-Part Fixture Make Financial Sense?</h3><p>How to think about fixture cost, repeat volume, setup savings, scrap reduction, operator consistency, and bottleneck machine capacity.</p><span class="coming-soon">Coming Soon</span></article><article class="article-card"><p class="eyebrow">Fixture Design</p><h3>What Makes a Good CNC Machining Fixture?</h3><p>Good machining fixtures control location, support repeatable loading, preserve tool access, clear chips, and make the correct setup easier to repeat.</p><span class="coming-soon">Coming Soon</span></article><article class="article-card"><p class="eyebrow">High-Mix CNC</p><h3>Fixture Design Checklist for High-Mix CNC Shops</h3><p>A practical checklist for repeat jobs, part-family fixtures, setup photos, datum control, clamp access, and build-ready documentation.</p><span class="coming-soon">Coming Soon</span></article><article class="article-card"><p class="eyebrow">Workholding Choices</p><h3>Soft Jaws vs. Dedicated Fixtures vs. Modular Fixture Plates</h3><p>How to compare workholding options when repeatability, setup time, production volume, and fixture cost all matter.</p><span class="coming-soon">Coming Soon</span></article></div></div></section>
-
-    <section id="about" class="section about-section"><div class="container about-grid"><div class="reveal"><p class="eyebrow">About Eden Industrial Systems</p><h2>Fixture design grounded in CNC production experience.</h2><p>Good CNC fixtures are not just modeled correctly. They have to locate the part consistently, leave room for tools and chips, clamp predictably, and make the correct loading process easy for the operator to repeat.</p><p>Eden Industrial Systems focuses on multi-part fixture concepts, fixture plates, soft jaw strategies, and build-ready documentation for shops running repeat production work.</p><a class="button secondary" href="#contact">Request a Fixture Review</a></div><div class="capability-panel reveal delay-1"><p class="eyebrow">Core Capabilities</p><div class="capability-tags" aria-label="Capabilities"><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M5 8h9a5 5 0 0 1 0 10H5"></path><path d="M5 8v10"></path></svg>Multi-Part Fixtures</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M14 4l6 6-9 9H5v-6l9-9z"></path><path d="M12 6l6 6"></path></svg>Fixture Plates</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M12 3l8 4v10l-8 4-8-4V7l8-4z"></path><path d="M4 7l8 4 8-4"></path><path d="M12 11v10"></path></svg>Soft Jaw Strategies</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 5h16v14H4z"></path><path d="M8 9h8M8 13h5"></path></svg>Datum Control</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M4 17h16"></path><path d="M6 17V9h4v8"></path><path d="M14 17V5h4v12"></path></svg>Setup Time Reduction</span><span><svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path d="M7 3h8l4 4v14H7z"></path><path d="M15 3v5h4"></path><path d="M10 13h6M10 17h6"></path></svg>Build-Ready Drawings</span></div></div></div></section>
+    <section id="about" class="section about-section"><div class="container about-grid"><div class="reveal"><p class="eyebrow">About Eden Industrial Systems</p><h2>Fixture design grounded in CNC production experience.</h2><p>Good CNC fixtures are not just modeled correctly. They have to locate the part consistently, leave room for tools and chips, clamp predictably, and make the correct loading process easy for the operator to repeat.</p><p>Eden Industrial Systems focuses on multi-part fixture concepts, fixture plates, soft jaw strategies, and build-ready documentation for shops running repeat production work.</p><a class="button secondary" href="#contact">Request a Fixture Review</a></div><div class="capability-panel reveal delay-1"><p class="eyebrow">Core Capabilities</p><div class="capability-tags" aria-label="Capabilities"><span>Multi-Part Fixtures</span><span>Fixture Plates</span><span>Soft Jaw Strategies</span><span>Datum Control</span><span>Setup Time Reduction</span><span>Build-Ready Drawings</span></div></div></div></section>
 
     <section id="contact" class="contact-band"><div class="container contact-flow-grid reveal"><div class="contact-primary"><div class="footer-brand"><span class="logo-mark">E</span><div><strong>Eden</strong><small>Industrial Systems</small></div></div><p class="eyebrow">Request a Fixture Review</p><h2>Send a repeat part, setup photo, or fixture problem.</h2><p>Send a part drawing, current setup photo, and a short description of what is slow, inconsistent, or hard to repeat. Eden Industrial Systems will review the fixture opportunity and recommend a practical next step.</p><a class="contact-email" href="mailto:engineering@edenindustrialsystems.com?subject=Fixture%20Review">engineering@edenindustrialsystems.com</a></div><div class="contact-guidance-grid" aria-label="Fixture review contact guidance"><div class="contact-guidance-card"><p class="eyebrow">What to Send</p><h3>Helpful context for a fixture review</h3><ul class="contact-guidance-list"><li>Part drawing or CAD screenshot.</li><li>Current setup photo.</li><li>Machine type: VMC, HMC, lathe, mill-turn, or other.</li><li>Current setup time.</li><li>Cycle time if known.</li><li>Parts per run or runs per month.</li><li>What is slow, inconsistent, difficult, or hard to repeat.</li></ul></div><div class="contact-guidance-card"><p class="eyebrow">Project Goal</p><h3>What improvement are you trying to make?</h3><ul class="contact-guidance-list"><li>Faster setup.</li><li>More parts per cycle.</li><li>Better repeatability.</li><li>Easier loading.</li><li>Faster first-piece approval.</li><li>Build-ready fixture drawings for your shop or vendor.</li></ul></div><p class="contact-next-step"><strong>Next step:</strong> email <strong>engineering@edenindustrialsystems.com</strong> with <strong>Fixture Review</strong> in the subject line. A rough drawing, setup photo, and short explanation are enough to start.</p></div></div></section>
   </main>


### PR DESCRIPTION
Updates the homepage to remove the Common Fixture Problems and Resources sections, remove Resources from navigation, simplify Industries Served, and refocus the Focused Service section on good-fit fixture design project types.